### PR TITLE
fix: window sizing on startup + keyboard focus after UI (#83, #84)

### DIFF
--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -205,8 +205,11 @@ static void process_pending_dialog()
       break;
   }
 
-  // Clear ImGui focus so keyboard events reach the emulator immediately
+  // Clear ImGui focus so keyboard events reach the emulator immediately.
+  // SetWindowFocus(NULL) alone doesn't clear WantCaptureKeyboard — native
+  // file dialogs can leave it stuck, blocking all CPC keyboard input.
   ImGui::SetWindowFocus(NULL);
+  ImGui::GetIO().WantCaptureKeyboard = false;
 }
 
 // ─────────────────────────────────────────────────

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -3429,6 +3429,20 @@ int koncpc_main (int argc, char **argv)
 #endif
       topbar_height_px = imgui_topbar_height();
       video_set_topbar(nullptr, topbar_height_px);
+      // Re-resize window now that topbar height is known (video_init runs
+      // before topbar setup, so its resize used topbar_height=0).
+      if (CPC.scr_scale > 0 && mainSDLWindow) {
+         static const float sf[] = { 0.f, 1.f, 1.5f, 2.f, 3.f };
+         if (CPC.scr_scale < sizeof(sf)/sizeof(sf[0])) {
+            float f = sf[CPC.scr_scale];
+            int new_w = static_cast<int>(CPC_RENDER_WIDTH * f);
+            int new_h = CPC.scr_crt_aspect
+                      ? static_cast<int>(new_w * 3.f / 4.f)
+                      : static_cast<int>(CPC_VISIBLE_SCR_HEIGHT * f);
+            new_h += video_get_topbar_height() + video_get_bottombar_height();
+            SDL_SetWindowSize(mainSDLWindow, new_w, new_h);
+         }
+      }
       mouse_init();
 
       if (audio_init()) {


### PR DESCRIPTION
## Summary

- **Window sizing (#83)**: `video_init()` resized the window before topbar height was known (0). Added re-resize after `video_set_topbar()` sets the correct height.
- **Keyboard focus (#84)**: Native file dialogs leave `WantCaptureKeyboard` stuck after closing. Now explicitly cleared in `process_pending_dialog()`.

Closes #83, closes #84.

## Test plan
- [ ] Launch emulator — window should fit CPC display + topbar at chosen scale
- [ ] Open menu → Media → Load Disk A → select file → type on CPC keyboard — keys should work
- [ ] Same test in docked (single window) mode
- [ ] `make test` passes (1026/1028, 2 skipped)