### PR TITLE
fix: keyboard focus stuck after file dialogs + window sizing (#83, #84)

### DIFF
--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -117,7 +117,6 @@ static void process_pending_dialog()
       } else
         imgui_toast_error("Failed to load disk: " + fname);
       CPC.current_dsk_path = dir;
-      if (action == FileDialogAction::LoadDiskA) imgui_close_menu();
       break;
     case FileDialogAction::LoadDiskB:
     case FileDialogAction::LoadDiskB_LED:
@@ -128,7 +127,6 @@ static void process_pending_dialog()
       } else
         imgui_toast_error("Failed to load disk: " + fname);
       CPC.current_dsk_path = dir;
-      if (action == FileDialogAction::LoadDiskB) imgui_close_menu();
       break;
     case FileDialogAction::SaveDiskA:
       if (dsk_save(path, &driveA) == 0)
@@ -152,7 +150,6 @@ static void process_pending_dialog()
       } else
         imgui_toast_error("Failed to load snapshot: " + fname);
       CPC.current_snap_path = dir;
-      imgui_close_menu();
       break;
     case FileDialogAction::SaveSnapshot:
       if (snapshot_save(path) == 0)
@@ -170,7 +167,6 @@ static void process_pending_dialog()
       } else
         imgui_toast_error("Failed to load tape: " + fname);
       CPC.current_tape_path = dir;
-      imgui_close_menu();
       break;
     case FileDialogAction::LoadTape_LED:
       CPC.tape.file = path;
@@ -191,7 +187,6 @@ static void process_pending_dialog()
         imgui_toast_error("Failed to load cartridge: " + fname);
       CPC.current_cart_path = dir;
       emulator_reset();
-      imgui_close_menu();
       break;
     case FileDialogAction::LoadROM:
       if (rom_slot >= 0 && rom_slot < MAX_ROM_SLOTS)
@@ -205,11 +200,12 @@ static void process_pending_dialog()
       break;
   }
 
-  // Clear ImGui focus so keyboard events reach the emulator immediately.
-  // SetWindowFocus(NULL) alone doesn't clear WantCaptureKeyboard — native
-  // file dialogs can leave it stuck, blocking all CPC keyboard input.
+  // Always close the menu after any file dialog completes.
+  // For status bar LED actions, show_menu is already false (no-op).
+  // For Options sub-dialogs, imgui_close_menu() skips unpause while
+  // show_options is still true.
+  imgui_close_menu();
   ImGui::SetWindowFocus(NULL);
-  ImGui::GetIO().WantCaptureKeyboard = false;
 }
 
 // ─────────────────────────────────────────────────
@@ -521,29 +517,9 @@ void imgui_render_ui()
     s_bottombar_height_dirty = false;
   }
 
-  // Keyboard capture policy: let physical keys reach the CPC when no
-  // keyboard-consuming UI is active.
-  // - Classic mode: keys go to CPC unless any UI window is open.
-  //   Uses imgui_any_keyboard_ui_active() (same as event filter).
-  // - Docked mode: devtools are always visible as docked tabs, so we
-  //   only block on modal UI / text input. CPC screen gets keyboard
-  //   when focused, even with devtools docked alongside.
-  {
-    if (CPC.workspace_layout == t_CPC::WorkspaceLayoutMode::Docked) {
-      bool modal_ui = ImGui::GetIO().WantTextInput
-          || imgui_state.show_menu || imgui_state.show_options
-          || imgui_state.show_about || imgui_state.show_quit_confirm
-          || g_command_palette.is_open()
-          || ImGui::IsPopupOpen("", ImGuiPopupFlags_AnyPopup);
-      if (!modal_ui && imgui_state.cpc_screen_focused) {
-        ImGui::GetIO().WantCaptureKeyboard = false;
-      }
-    } else {
-      if (!imgui_any_keyboard_ui_active()) {
-        ImGui::GetIO().WantCaptureKeyboard = false;
-      }
-    }
-  }
+  // Keyboard routing is handled at the SDL event level in kon_cpc_ja.cpp
+  // using imgui_any_keyboard_ui_active() as the single source of truth.
+  // No WantCaptureKeyboard override needed here.
 }
 
 // ─────────────────────────────────────────────────

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -3429,20 +3429,7 @@ int koncpc_main (int argc, char **argv)
 #endif
       topbar_height_px = imgui_topbar_height();
       video_set_topbar(nullptr, topbar_height_px);
-      // Re-resize window now that topbar height is known (video_init runs
-      // before topbar setup, so its resize used topbar_height=0).
-      if (CPC.scr_scale > 0 && mainSDLWindow) {
-         static const float sf[] = { 0.f, 1.f, 1.5f, 2.f, 3.f };
-         if (CPC.scr_scale < sizeof(sf)/sizeof(sf[0])) {
-            float f = sf[CPC.scr_scale];
-            int new_w = static_cast<int>(CPC_RENDER_WIDTH * f);
-            int new_h = CPC.scr_crt_aspect
-                      ? static_cast<int>(new_w * 3.f / 4.f)
-                      : static_cast<int>(CPC_VISIBLE_SCR_HEIGHT * f);
-            new_h += video_get_topbar_height() + video_get_bottombar_height();
-            SDL_SetWindowSize(mainSDLWindow, new_w, new_h);
-         }
-      }
+      // video_set_topbar handles the window resize using compute_window_size()
       mouse_init();
 
       if (audio_init()) {
@@ -3684,14 +3671,12 @@ int koncpc_main (int argc, char **argv)
            bool is_mouse_event_imgui = (event.type == SDL_EVENT_MOUSE_MOTION || event.type == SDL_EVENT_MOUSE_BUTTON_DOWN || event.type == SDL_EVENT_MOUSE_BUTTON_UP || event.type == SDL_EVENT_MOUSE_WHEEL);
            bool is_virtual_key = is_key_event && event.key.windowID == 0;
 
-           // Block keyboard for ImGui unless ONLY the vkeyboard has focus.
-           // imgui_any_keyboard_ui_active() is the single source of truth
-           // (defined in imgui_ui.cpp, also used by the capture policy there).
-           bool imgui_wants_kbd = io.WantCaptureKeyboard;
-           if (imgui_wants_kbd && imgui_state.show_vkeyboard
-               && !imgui_any_keyboard_ui_active()) {
-             imgui_wants_kbd = false;
-           }
+           // Use our own policy, not ImGui's WantCaptureKeyboard — ImGui's
+           // NewFrame() sets it based on internal focus state which can stay
+           // stuck after native file dialogs or menu interactions.
+           // imgui_any_keyboard_ui_active() checks actual dialog/menu/devtools
+           // state and is the single source of truth.
+           bool imgui_wants_kbd = imgui_any_keyboard_ui_active();
 
            if (((is_key_event && !is_virtual_key) && imgui_wants_kbd) || (is_text_event && imgui_wants_kbd) || (is_mouse_event_imgui && io.WantCaptureMouse)) {
              continue;

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1715,6 +1715,26 @@ void compute_rects_for_tests(SDL_Rect* src, SDL_Rect* dst, Uint8 half_pixels)
   compute_rects(src, dst, half_pixels);
 }
 
+// Scale factor table shared with compute_scale and Options combo.
+static const float video_scale_factors[] = { 0.f, 1.f, 1.5f, 2.f, 3.f };
+static const int video_scale_factors_count = sizeof(video_scale_factors) / sizeof(video_scale_factors[0]);
+
+// Compute window dimensions for the current scale + bars + 4:3 aspect.
+// For Fit mode (scr_scale=0), returns false (don't resize — keep user's window).
+static bool compute_window_size(int& out_w, int& out_h) {
+  float f;
+  if (CPC.scr_scale > 0 && static_cast<int>(CPC.scr_scale) < video_scale_factors_count)
+    f = video_scale_factors[CPC.scr_scale];
+  else
+    return false;  // Fit mode — don't resize
+  out_w = static_cast<int>(CPC_RENDER_WIDTH * f) + devtools_panel_width;
+  int cpc_h = CPC.scr_crt_aspect
+            ? static_cast<int>(CPC_RENDER_WIDTH * f * 3.f / 4.f)
+            : static_cast<int>(CPC_VISIBLE_SCR_HEIGHT * f);
+  out_h = max(cpc_h + topbar_height + bottombar_height, devtools_panel_height);
+  return true;
+}
+
 void video_set_devtools_panel(SDL_Surface* surface, int width, int height, int scale)
 {
   if (!mainSDLWindow || !surface) return;
@@ -1723,10 +1743,11 @@ void video_set_devtools_panel(SDL_Surface* surface, int width, int height, int s
   devtools_panel_height = height * scale;
   devtools_panel_surface_width = surface->w;
   devtools_panel_surface_height = surface->h;
-  devtools_cpc_height = CPC_VISIBLE_SCR_HEIGHT * CPC.scr_scale;
-  int win_width = static_cast<int>(CPC_RENDER_WIDTH * CPC.scr_scale) + devtools_panel_width;
-  int win_height = max(devtools_cpc_height + topbar_height + bottombar_height, devtools_panel_height);
-  SDL_SetWindowSize(mainSDLWindow, win_width, win_height);
+  int w, h;
+  if (compute_window_size(w, h)) {
+    devtools_cpc_height = h - topbar_height - bottombar_height;
+    SDL_SetWindowSize(mainSDLWindow, w, h);
+  }
   if (vid_plugin && vid) compute_scale(vid_plugin, vid->w, vid->h);
 }
 
@@ -1739,9 +1760,9 @@ void video_clear_devtools_panel()
   devtools_panel_surface_height = 0;
   devtools_cpc_height = 0;
   if (mainSDLWindow) {
-    int win_width = CPC_RENDER_WIDTH * CPC.scr_scale;
-    int win_height = CPC_VISIBLE_SCR_HEIGHT * CPC.scr_scale + topbar_height + bottombar_height;
-    SDL_SetWindowSize(mainSDLWindow, win_width, win_height);
+    int w, h;
+    if (compute_window_size(w, h))
+      SDL_SetWindowSize(mainSDLWindow, w, h);
   }
   if (vid_plugin && vid) compute_scale(vid_plugin, vid->w, vid->h);
 }
@@ -1751,9 +1772,9 @@ void video_set_topbar(SDL_Surface* surface, int height)
   if (!mainSDLWindow) return;
   topbar_surface = surface;
   topbar_height = height;
-  int win_width = static_cast<int>(CPC_RENDER_WIDTH * CPC.scr_scale) + devtools_panel_width;
-  int win_height = max(static_cast<int>(CPC_VISIBLE_SCR_HEIGHT * CPC.scr_scale) + topbar_height + bottombar_height, devtools_panel_height);
-  SDL_SetWindowSize(mainSDLWindow, win_width, win_height);
+  int w, h;
+  if (compute_window_size(w, h))
+    SDL_SetWindowSize(mainSDLWindow, w, h);
   if (vid_plugin && vid) compute_scale(vid_plugin, vid->w, vid->h);
 }
 
@@ -1762,9 +1783,9 @@ void video_clear_topbar()
   topbar_surface = nullptr;
   topbar_height = 0;
   if (mainSDLWindow) {
-    int win_width = static_cast<int>(CPC_RENDER_WIDTH * CPC.scr_scale) + devtools_panel_width;
-    int win_height = max(static_cast<int>(CPC_VISIBLE_SCR_HEIGHT * CPC.scr_scale) + bottombar_height, devtools_panel_height);
-    SDL_SetWindowSize(mainSDLWindow, win_width, win_height);
+    int w, h;
+    if (compute_window_size(w, h))
+      SDL_SetWindowSize(mainSDLWindow, w, h);
   }
   if (vid_plugin && vid) compute_scale(vid_plugin, vid->w, vid->h);
 }
@@ -1798,9 +1819,9 @@ void video_set_bottombar(int height)
 {
   if (!mainSDLWindow) return;
   bottombar_height = height;
-  int win_width = static_cast<int>(CPC_RENDER_WIDTH * CPC.scr_scale) + devtools_panel_width;
-  int win_height = max(static_cast<int>(CPC_VISIBLE_SCR_HEIGHT * CPC.scr_scale) + topbar_height + bottombar_height, devtools_panel_height);
-  SDL_SetWindowSize(mainSDLWindow, win_width, win_height);
+  int w, h;
+  if (compute_window_size(w, h))
+    SDL_SetWindowSize(mainSDLWindow, w, h);
   if (vid_plugin && vid) compute_scale(vid_plugin, vid->w, vid->h);
 }
 


### PR DESCRIPTION
## Summary

- **Keyboard focus (#84)**: `process_pending_dialog()` only called `imgui_close_menu()` for some actions (Load Disk, Load Tape) but not others (Save Disk, Save Snapshot). Menu stayed open → `show_menu` true → all CPC keyboard blocked. Fix: single unconditional `imgui_close_menu()` after the switch.
- **Event loop**: now uses `imgui_any_keyboard_ui_active()` directly instead of ImGui's `WantCaptureKeyboard` (unreliable after native dialogs). Removed dead keyboard capture policy override.
- **Window sizing (#83)**: `video_set_topbar/bottombar/devtools_panel` used `scr_scale` as a raw multiplier instead of index into scale factor table, ignoring 4:3 aspect. Extracted `compute_window_size()` helper.

Closes #83, closes #84.

## Test plan
- [ ] Menu → Save Disk A → pick file → type → keys reach CPC
- [ ] Menu → Load Disk A → pick file → type → keys reach CPC
- [ ] Status bar LED → load disk → type → keys reach CPC
- [ ] Options → Load ROM → Options stays open, keyboard captured
- [ ] Quit confirmation / About popups capture keyboard
- [ ] Window sizes correctly on startup with 4:3 aspect
- [ ] `make test` passes (1026/1028, 2 skipped)