### PR TITLE
feat(ui): route kon_cpc_ja event pump through IUiHost (P1.5.1 step 2)

### DIFF
--- a/src/imgui_ui_host.cpp
+++ b/src/imgui_ui_host.cpp
@@ -1,0 +1,100 @@
+// ImGuiUiHost — concrete IUiHost wired to Dear ImGui and SDL3.
+//
+// Each method delegates to the existing free function or backend call
+// that the rest of the codebase used directly before P1.5.1.  Two
+// things to be careful of:
+//
+//   1. ImGui::GetIO() requires an active ImGui context (created in
+//      imgui_init_ui() during video plugin init).  Before that point
+//      ImGui::GetCurrentContext() is null and any GetIO call segfaults.
+//      Every method here guards with GetCurrentContext() and returns a
+//      safe default if the context isn't up yet — matches NullUiHost
+//      semantics so pre-init code paths don't crash.
+//
+//   2. This file is part of the MODERN_UI build only.  In the future
+//      headless build (P1.5.2) it won't be compiled, and the NullUiHost
+//      stays installed as the default.
+//
+// Phase: P1.5.1 sub-PR 2 (beads-1az).
+
+#include "imgui_ui_host.h"
+
+#include "imgui.h"
+#include "imgui_impl_sdl3.h"
+#include "imgui_ui.h"
+
+#include <SDL3/SDL_events.h>
+
+namespace {
+
+// Map our backend-agnostic UiToastLevel to the ImGui-side enum so we
+// don't leak that enum across the iui_host.h boundary.  Values are 1:1
+// (UiToastLevel was deliberately defined to match) — this switch is
+// just defensive in case either enum gains members later.
+ImGuiUIState::ToastLevel to_imgui_toast_level(UiToastLevel level) {
+    switch (level) {
+        case UiToastLevel::Info:    return ImGuiUIState::ToastLevel::Info;
+        case UiToastLevel::Success: return ImGuiUIState::ToastLevel::Success;
+        case UiToastLevel::Error:   return ImGuiUIState::ToastLevel::Error;
+    }
+    return ImGuiUIState::ToastLevel::Info;
+}
+
+} // namespace
+
+void ImGuiUiHost::process_event(const SDL_Event& ev) {
+    if (!ImGui::GetCurrentContext()) {
+        return;  // Pre-init: drop the event.  The main loop's emulator
+                 // dispatch still runs below this call in kon_cpc_ja.cpp.
+    }
+    ImGui_ImplSDL3_ProcessEvent(&ev);
+}
+
+bool ImGuiUiHost::wants_capture_keyboard() const {
+    if (!ImGui::GetCurrentContext()) return false;
+    return ImGui::GetIO().WantCaptureKeyboard;
+}
+
+bool ImGuiUiHost::wants_capture_mouse() const {
+    if (!ImGui::GetCurrentContext()) return false;
+    return ImGui::GetIO().WantCaptureMouse;
+}
+
+bool ImGuiUiHost::any_keyboard_ui_active() const {
+    if (!ImGui::GetCurrentContext()) return false;
+    return imgui_any_keyboard_ui_active();
+}
+
+void ImGuiUiHost::toast(UiToastLevel level, const std::string& message) {
+    if (!ImGui::GetCurrentContext()) {
+        // No UI to show on — fall through to stderr like NullUiHost.
+        // Otherwise diagnostics during cold startup vanish silently.
+        const char* tag = "info";
+        switch (level) {
+            case UiToastLevel::Info:    tag = "info";    break;
+            case UiToastLevel::Success: tag = "success"; break;
+            case UiToastLevel::Error:   tag = "error";   break;
+        }
+        std::fprintf(stderr, "[toast/%s] %s\n", tag, message.c_str());
+        return;
+    }
+    imgui_toast(message, to_imgui_toast_level(level));
+}
+
+// -- Install at startup ----------------------------------------------
+//
+// A file-scope global + static-init pair replaces the NullUiHost default
+// with our ImGuiUiHost before main() runs.  This means:
+//   - kon_cpc_ja.cpp:main can call ui_host() from the very first line
+//     and get the right impl.
+//   - We don't need to plumb an explicit init point through the existing
+//     startup sequence (argparse → emulator_init → video_init → ...).
+//   - The headless build (P1.5.2) just doesn't compile this TU, so the
+//     null host stays installed.
+namespace {
+ImGuiUiHost g_imgui_host_instance;
+struct AutoInstaller {
+    AutoInstaller() { install_ui_host(&g_imgui_host_instance); }
+};
+[[maybe_unused]] AutoInstaller g_auto_installer;
+} // namespace

--- a/src/imgui_ui_host.cpp
+++ b/src/imgui_ui_host.cpp
@@ -23,6 +23,7 @@
 #include "imgui_impl_sdl3.h"
 #include "imgui_ui.h"
 
+#include <cstdio>
 #include <SDL3/SDL_events.h>
 
 namespace {

--- a/src/imgui_ui_host.h
+++ b/src/imgui_ui_host.h
@@ -1,0 +1,24 @@
+// ImGuiUiHost — concrete IUiHost implementation backed by Dear ImGui
+// and the SDL3 platform backend.  Compiled only in MODERN_UI builds.
+//
+// The host is a thin wrapper around existing free functions in
+// imgui_ui.cpp + the imgui_impl_sdl3 backend.  It exists to:
+//   1. Give kon_cpc_ja.cpp's event pump an interface to call so that
+//      the main loop stops referencing ImGui directly.
+//   2. Provide a single installation point (see imgui_ui_host.cpp)
+//      that replaces NullUiHost at startup.
+//
+// Phase: P1.5.1 sub-PR 2 (beads-1az).
+
+#pragma once
+
+#include "iui_host.h"
+
+class ImGuiUiHost final : public IUiHost {
+  public:
+    void process_event(const SDL_Event& ev) override;
+    bool wants_capture_keyboard() const override;
+    bool wants_capture_mouse()    const override;
+    bool any_keyboard_ui_active() const override;
+    void toast(UiToastLevel level, const std::string& message) override;
+};

--- a/src/iui_host.cpp
+++ b/src/iui_host.cpp
@@ -74,6 +74,12 @@ IUiHost& ui_host() {
     return *expected;
 }
 
+IUiHost* install_ui_host(IUiHost* host) {
+    IUiHost* prev = g_current_host.exchange(host ? host : &null_host_singleton(),
+                                            std::memory_order_acq_rel);
+    return prev ? prev : &null_host_singleton();
+}
+
 UiHostOverride::UiHostOverride(IUiHost* test_host) {
     // Snapshot the current host before installing the override.  If
     // nobody has called ui_host() yet, fall back to the null host so

--- a/src/iui_host.cpp
+++ b/src/iui_host.cpp
@@ -39,25 +39,38 @@ class NullUiHost final : public IUiHost {
     }
 };
 
-// Process-wide default.  Constructed on first use (avoids static-init
-// ordering pitfalls — `ui_host()` may be called from any TU's init).
+// Process-wide null-host default.  Function-local static so that the
+// first caller's thread-safe init (guaranteed by C++11 [stmt.dcl]/4)
+// is the moment the singleton becomes valid — no dependence on
+// translation-unit order.
 NullUiHost& null_host_singleton() {
     static NullUiHost instance;
     return instance;
 }
 
-// Currently installed host.  Atomic because it's read/written from the
-// main (render) thread AND the Z80 thread — the latter can emit toasts
-// from emulation side-effects (e.g. tape autoload errors).  Starts as
-// nullptr and is lazily initialised to the null host on first ui_host()
-// call.  After that, swaps go through UiHostOverride which uses atomic
-// load/store as well.
-std::atomic<IUiHost*> g_current_host{nullptr};
+// Currently installed host.  Returned by a function-local static
+// accessor to dodge the static-initialization-order fiasco — if a TU
+// somewhere (e.g. imgui_ui_host.cpp's AutoInstaller) calls
+// install_ui_host() from its file-scope constructor, that constructor
+// can run before iui_host.cpp's namespace-scope dynamic init would
+// have, and a plain `std::atomic<IUiHost*> g_current_host{nullptr};`
+// could be re-zeroed afterwards, wiping the install.  Wrapping in a
+// function-local static defers initialisation to the first call,
+// which is guaranteed thread-safe and ordered.
+//
+// Still atomic because it's read/written from the main (render)
+// thread AND the Z80 thread — the latter can emit toasts from
+// emulation side-effects (e.g. tape autoload errors).
+std::atomic<IUiHost*>& host_atomic() {
+    static std::atomic<IUiHost*> instance{nullptr};
+    return instance;
+}
 
 } // namespace
 
 IUiHost& ui_host() {
-    IUiHost* h = g_current_host.load(std::memory_order_acquire);
+    auto& atom = host_atomic();
+    IUiHost* h = atom.load(std::memory_order_acquire);
     if (h) {
         return *h;
     }
@@ -65,9 +78,9 @@ IUiHost& ui_host() {
     // concurrent first-callers race-free converge on the same pointer.
     IUiHost* expected = nullptr;
     IUiHost* desired  = &null_host_singleton();
-    if (g_current_host.compare_exchange_strong(expected, desired,
-                                               std::memory_order_acq_rel,
-                                               std::memory_order_acquire)) {
+    if (atom.compare_exchange_strong(expected, desired,
+                                     std::memory_order_acq_rel,
+                                     std::memory_order_acquire)) {
         return *desired;
     }
     // Lost the race — `expected` now holds the winner.
@@ -75,24 +88,25 @@ IUiHost& ui_host() {
 }
 
 IUiHost* install_ui_host(IUiHost* host) {
-    IUiHost* prev = g_current_host.exchange(host ? host : &null_host_singleton(),
-                                            std::memory_order_acq_rel);
+    IUiHost* prev = host_atomic().exchange(host ? host : &null_host_singleton(),
+                                           std::memory_order_acq_rel);
     return prev ? prev : &null_host_singleton();
 }
 
 UiHostOverride::UiHostOverride(IUiHost* test_host) {
+    auto& atom = host_atomic();
     // Snapshot the current host before installing the override.  If
     // nobody has called ui_host() yet, fall back to the null host so
     // the destructor restores a sensible value rather than nullptr.
-    IUiHost* prev = g_current_host.load(std::memory_order_acquire);
+    IUiHost* prev = atom.load(std::memory_order_acquire);
     if (!prev) {
         prev = &null_host_singleton();
     }
     previous_ = prev;
-    g_current_host.store(test_host ? test_host : &null_host_singleton(),
-                         std::memory_order_release);
+    atom.store(test_host ? test_host : &null_host_singleton(),
+               std::memory_order_release);
 }
 
 UiHostOverride::~UiHostOverride() {
-    g_current_host.store(previous_, std::memory_order_release);
+    host_atomic().store(previous_, std::memory_order_release);
 }

--- a/src/iui_host.h
+++ b/src/iui_host.h
@@ -83,8 +83,18 @@ class IUiHost {
 //   - Headless build (P1.5.2)   → returns the null host.
 // The pointer is non-owning; the host lives for the duration of the
 // process.  Safe to call before any UI init — null host responds with
-// safe defaults until the modern host is initialised.
+// safe defaults until the modern host is installed.
 IUiHost& ui_host();
+
+// Install a concrete IUiHost as the process-wide implementation.  The
+// caller retains ownership; the host pointer must outlive any call to
+// ui_host() that returns it.  Passing nullptr restores the null host.
+// Returns the previously installed host (or null host if first call).
+//
+// Use from production code — for example, the modern-UI build installs
+// an ImGuiUiHost via a static constructor in src/imgui_ui_host.cpp.
+// Tests should prefer UiHostOverride (below) for scoped install/restore.
+IUiHost* install_ui_host(IUiHost* host);
 
 // Test-only: install a custom host for unit tests.  Restores the
 // previous host when the returned scope-guard is destroyed.  No-op

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -77,9 +77,14 @@ static inline Uint32 MapRGBSurface(SDL_Surface* surface, Uint8 r, Uint8 g, Uint8
 #include "memory_bus.h"
 #include "io_bus.h"
 
-#include "imgui.h"
-#include "imgui_impl_sdl3.h"
+// imgui.h / imgui_impl_sdl3.h are intentionally NOT included here.
+// The main loop talks to the UI through IUiHost only (P1.5.1).
+// imgui_ui.h is still included because the global `imgui_state` struct
+// (telemetry / flag bus) is defined there and is a public data
+// contract — see iui_host.h header for why imgui_state stays free-
+// standing instead of being absorbed into the host interface.
 #include "imgui_ui.h"
+#include "iui_host.h"
 #include "command_palette.h"
 #include "menu_actions.h"
 
@@ -4186,8 +4191,11 @@ int koncpc_main (int argc, char **argv)
            }
          }
 
-         // Feed event to Dear ImGui
-         ImGui_ImplSDL3_ProcessEvent(&event);
+         // Feed event to the UI host (Dear ImGui in modern builds, no-op
+         // in headless).  Was a direct ImGui_ImplSDL3_ProcessEvent call —
+         // routed through IUiHost in P1.5.1 so the main loop doesn't
+         // depend on ImGui at the boundary.
+         ui_host().process_event(event);
 
          // ── Drag-and-drop file loading ──
          if (event.type == SDL_EVENT_DROP_FILE) {
@@ -4254,28 +4262,27 @@ int koncpc_main (int argc, char **argv)
            }
          }
 
-         // If ImGui wants input, skip emulator processing.
+         // If the UI wants input, skip emulator processing.
          // Exception: virtual keyboard events (windowID=0) always reach the emulator.
          //
-         // WantCaptureKeyboard blocks when menus, dropdowns, devtools, or any ImGui
-         // window has focus. Special case: the virtual keyboard only uses mouse clicks,
-         // so when it's the sole reason WantCaptureKeyboard is set, let physical keys
-         // reach the CPC. Any other UI (menus, text fields, devtools) takes priority.
+         // Keyboard policy uses ui_host().any_keyboard_ui_active() rather than
+         // ImGui's WantCaptureKeyboard — the latter is set by ImGui::NewFrame()
+         // based on internal focus state that can stay stuck after native file
+         // dialogs or menu interactions.  any_keyboard_ui_active() checks the
+         // actual dialog/menu/devtools state and is the single source of truth.
+         // Mouse policy still routes through wants_capture_mouse(), which mirrors
+         // ImGui's WantCaptureMouse — that one isn't subject to the same stuck-
+         // focus pathology.
          {
-           ImGuiIO& io = ImGui::GetIO();
+           IUiHost& ui = ui_host();
            bool is_key_event = (event.type == SDL_EVENT_KEY_DOWN || event.type == SDL_EVENT_KEY_UP);
            bool is_text_event = (event.type == SDL_EVENT_TEXT_INPUT);
            bool is_mouse_event_imgui = (event.type == SDL_EVENT_MOUSE_MOTION || event.type == SDL_EVENT_MOUSE_BUTTON_DOWN || event.type == SDL_EVENT_MOUSE_BUTTON_UP || event.type == SDL_EVENT_MOUSE_WHEEL);
            bool is_virtual_key = is_key_event && event.key.windowID == 0;
 
-           // Use our own policy, not ImGui's WantCaptureKeyboard — ImGui's
-           // NewFrame() sets it based on internal focus state which can stay
-           // stuck after native file dialogs or menu interactions.
-           // imgui_any_keyboard_ui_active() checks actual dialog/menu/devtools
-           // state and is the single source of truth.
-           bool imgui_wants_kbd = imgui_any_keyboard_ui_active();
+           bool ui_wants_kbd = ui.any_keyboard_ui_active();
 
-           if (((is_key_event && !is_virtual_key) && imgui_wants_kbd) || (is_text_event && imgui_wants_kbd) || (is_mouse_event_imgui && io.WantCaptureMouse)) {
+           if (((is_key_event && !is_virtual_key) && ui_wants_kbd) || (is_text_event && ui_wants_kbd) || (is_mouse_event_imgui && ui.wants_capture_mouse())) {
              continue;
            }
          }


### PR DESCRIPTION
Sub-PR 2 of **beads-1az** (P1.5.1 — Core/UI separation refactor). Builds on #124 (which landed the `IUiHost` interface) by:

1. Adding the concrete **`ImGuiUiHost`** that the modern build installs at startup.
2. **Routing kon_cpc_ja.cpp's 2 real ImGui callsites** through `ui_host()`.
3. **Dropping** direct `#include "imgui.h"` and `#include "imgui_impl_sdl3.h"` from the main loop — it now only includes `imgui_ui.h` for the global `imgui_state` data bus.

## Callsites moved

| Before | After |
|--------|-------|
| `ImGui_ImplSDL3_ProcessEvent(&event)` | `ui_host().process_event(event)` |
| `ImGuiIO& io = ImGui::GetIO(); io.WantCaptureMouse` | `ui_host().wants_capture_mouse()` |
| `imgui_any_keyboard_ui_active()` | `ui_host().any_keyboard_ui_active()` |

The keyboard-capture policy comment is preserved verbatim — the "WantCaptureKeyboard stuck after native file dialogs" invariant still holds, and `any_keyboard_ui_active()` is still the single source of truth.

## New files

- **`src/imgui_ui_host.{h,cpp}`** — concrete `ImGuiUiHost`. Each method delegates to the existing ImGui backend call but guards on `ImGui::GetCurrentContext()` so calls during cold startup (before any video plugin has created the context) are safe no-ops with NullUiHost semantics — including `toast`, which falls back to stderr.

  Installed via a file-scope global + auto-installer struct so `install_ui_host(&g_imgui_host_instance)` runs before `main()`. In a future headless build this TU is excluded and `NullUiHost` stays in place.

## Interface additions

- `install_ui_host(IUiHost*) -> IUiHost*` — non-scoped install (production use). Atomic exchange. Complements the existing test-only `UiHostOverride`. Returns the previously installed host.

## kon_cpc_ja.cpp include cleanup

Drops direct `#include "imgui.h"` and `#include "imgui_impl_sdl3.h"`. Comment block explains why this is intentional — the main loop now talks to the UI only through `IUiHost`. `imgui_ui.h` stays because `ImGuiUIState::TAPE_WAVE_SAMPLES` and `imgui_state` are still publish/subscribe contract.

## Verification

- `make -j ARCH=macos test_runner` — clean build, no new warnings (2 pre-existing `unused display_ms` warnings at lines 4685/5068 unchanged)
- `./test_runner --gtest_shuffle` — **1114/1114 pass**, same 2 pre-existing `RamExpansion` skips

## Next sub-PR (P1.5.1 step 3)

Wrap `imgui_render_ui` / `imgui_render_topbar` / GPU `PrepareDrawData` into the `ImGuiUiHost` surface so `video.cpp` also goes through `ui_host()`. After that, step 4 adds the `KONCPC_BUILD_MODERN_UI` CMake flag and gates the isolated UI sources.
