### PR TITLE
feat(ui): route drag-drop toasts through IUiHost (P1.5.1 step 3)

### DIFF
--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -4210,44 +4210,44 @@ int koncpc_main (int argc, char **argv)
              if (ext == ".dsk" || ext == ".ipf" || ext == ".raw") {
                CPC.driveA.file = drop_path;
                if (file_load(CPC.driveA) == 0) {
-                 imgui_toast_success("Drive A: " + drop_fname);
+                 ui_host().toast(UiToastLevel::Success, "Drive A: " + drop_fname);
                  imgui_mru_push(CPC.mru_disks, drop_path);
                } else
-                 imgui_toast_error("Failed to load disk: " + drop_fname);
+                 ui_host().toast(UiToastLevel::Error, "Failed to load disk: " + drop_fname);
              } else if (ext == ".cdt" || ext == ".voc") {
                CPC.tape.file = drop_path;
                if (file_load(CPC.tape) == 0) {
-                 imgui_toast_success("Tape loaded: " + drop_fname);
+                 ui_host().toast(UiToastLevel::Success, "Tape loaded: " + drop_fname);
                  imgui_mru_push(CPC.mru_tapes, drop_path);
                  tape_scan_blocks();
                } else
-                 imgui_toast_error("Failed to load tape: " + drop_fname);
+                 ui_host().toast(UiToastLevel::Error, "Failed to load tape: " + drop_fname);
              } else if (ext == ".sna") {
                CPC.snapshot.file = drop_path;
                if (file_load(CPC.snapshot) == 0) {
-                 imgui_toast_success("Snapshot loaded: " + drop_fname);
+                 ui_host().toast(UiToastLevel::Success, "Snapshot loaded: " + drop_fname);
                  imgui_mru_push(CPC.mru_snaps, drop_path);
                } else
-                 imgui_toast_error("Failed to load snapshot: " + drop_fname);
+                 ui_host().toast(UiToastLevel::Error, "Failed to load snapshot: " + drop_fname);
              } else if (ext == ".cpr") {
                CPC.cartridge.file = drop_path;
                if (file_load(CPC.cartridge) == 0) {
-                 imgui_toast_success("Cartridge loaded: " + drop_fname);
+                 ui_host().toast(UiToastLevel::Success, "Cartridge loaded: " + drop_fname);
                  imgui_mru_push(CPC.mru_carts, drop_path);
                  emulator_reset();
                } else {
-                 imgui_toast_error("Failed to load cartridge: " + drop_fname);
+                 ui_host().toast(UiToastLevel::Error, "Failed to load cartridge: " + drop_fname);
                }
              } else if (ext == ".zip") {
                // Try as disk first (most common zip content)
                CPC.driveA.file = drop_path;
                if (file_load(CPC.driveA) == 0) {
-                 imgui_toast_success("Drive A: " + drop_fname);
+                 ui_host().toast(UiToastLevel::Success, "Drive A: " + drop_fname);
                  imgui_mru_push(CPC.mru_disks, drop_path);
                } else
-                 imgui_toast_error("Unsupported ZIP content: " + drop_fname);
+                 ui_host().toast(UiToastLevel::Error, "Unsupported ZIP content: " + drop_fname);
              } else {
-               imgui_toast_error("Unknown file type: " + drop_fname);
+               ui_host().toast(UiToastLevel::Error, "Unknown file type: " + drop_fname);
              }
            }
            continue;


### PR DESCRIPTION
Sub-PR 3 of **beads-1az** (P1.5.1 — Core/UI separation refactor). Routes the remaining 11 `imgui_toast_success/error` calls in `kon_cpc_ja.cpp`'s drag-drop handler through `ui_host().toast()`. Follow-up to #124 (interface) and #125 (event pump).

## Diff

11 lines changed, all in the drag-drop block around lines 4213–4250:

```cpp
- imgui_toast_success("Drive A: " + drop_fname);
+ ui_host().toast(UiToastLevel::Success, "Drive A: " + drop_fname);

- imgui_toast_error("Failed to load disk: " + drop_fname);
+ ui_host().toast(UiToastLevel::Error, "Failed to load disk: " + drop_fname);
```

…etc for the 9 success/error toasts across .dsk/.cdt/.sna/.cpr/.zip handlers, plus the 2 "unknown file type" / "unsupported ZIP" errors.

## Why this scope

After this PR, the main loop's only direct references to `imgui_ui.h` symbols are:

| Symbol | Reason it stays | Path forward |
|--------|-----------------|--------------|
| `imgui_state.*` field writes/reads | publish/subscribe telemetry bus — explicitly out-of-scope per P1.5.1 plan | n/a |
| `imgui_mru_push(vec, path)` | pure vector helper, doesn't touch ImGui despite the prefix | follow-up extraction not architecturally required |
| `ImGuiUIState::TAPE_WAVE_SAMPLES` constant | static array sizing | move with `imgui_state` if/when needed |

The `imgui_toast_*` free functions stay in `imgui_ui.h` for `devtools_ui.cpp`'s use (which is its own ImGui-coupled file and gets excluded by sub-PR 4's `KONCPC_BUILD_MODERN_UI` flag).

## Verification

- `make -j ARCH=macos test_runner` → clean build, **20 pre-existing warnings unchanged**
- `./test_runner --gtest_shuffle` → **1114/1114 pass**, same 2 `RamExpansion` skips

## Next (P1.5.1 step 4)

Add the `KONCPC_BUILD_MODERN_UI` CMake option (defaults ON), exclude `imgui_ui.cpp` / `imgui_ui_host.cpp` / `devtools_ui.cpp` / `command_palette.cpp` / `workspace_layout.cpp` / `video.cpp` sources when OFF. That's the actual headless-compile gate — sub-PR 4 closes Phase 1.5.1 and unblocks Phase 1.5.2 (the headless `koncpc-core` build target).
