### PR TITLE
feat(build): KONCPC_BUILD_MODERN_UI flag — close P1.5.1 (step 4)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,15 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 option(WITH_CURL  "Enable libcurl (M4 HTTP)"  OFF)
 option(WITH_JPEG  "Enable libjpeg (AVI rec)"  OFF)
 
+# Modern UI gate (P1.5.1 step 4).  ON = the current ImGui + SDL_GPU
+# build.  OFF = exclude UI-only sources from compilation, leaving the
+# core ready for a future headless main (P1.5.2) to wire up.  OFF is
+# an in-progress state: kon_cpc_ja.cpp still references imgui_state
+# from imgui_ui.h, so a full link with OFF will fail until P1.5.2
+# splits that header.  Defaulting ON keeps every existing build
+# (CI matrix, distro packages, local dev) bit-identical to today.
+option(KONCPC_BUILD_MODERN_UI "Build the ImGui + SDL_GPU modern UI" ON)
+
 # ── Git hash ─────────────────────────────────────────────
 execute_process(
     COMMAND git rev-parse --verify HEAD
@@ -61,17 +70,39 @@ else()
     enable_language(OBJCXX)
 endif()
 
+# ── UI-only source files (P1.5.1 step 4) ─────────────────
+# Files that have hard dependencies on Dear ImGui and/or the modern
+# UI widgets.  When KONCPC_BUILD_MODERN_UI=OFF these are excluded
+# from the library so the headless variant doesn't drag in ImGui
+# transitively.  Vendored ImGui itself is handled separately below.
+#
+# Keep in sync if a new UI-only TU is added; CI catches inclusion
+# regressions because the modern build still compiles them as today.
+set(MODERN_UI_SOURCES_REGEX
+    "src/(imgui_ui|imgui_ui_host|devtools_ui|command_palette|workspace_layout|video|TextEditor|LanguageDefinitions)\\.cpp$"
+)
+
+if(NOT KONCPC_BUILD_MODERN_UI)
+    message(STATUS "KONCPC_BUILD_MODERN_UI=OFF — excluding modern UI sources from koncepcja_lib")
+    message(STATUS "  Note: full link will fail until P1.5.2 lands a headless main and an ImGui-free imgui_ui.h split.")
+    list(FILTER APP_SOURCES EXCLUDE REGEX "${MODERN_UI_SOURCES_REGEX}")
+endif()
+
 # ── Vendored ImGui sources ───────────────────────────────
 set(IMGUI_DIR ${CMAKE_SOURCE_DIR}/vendor/imgui)
-set(IMGUI_SOURCES
-    ${IMGUI_DIR}/imgui.cpp
-    ${IMGUI_DIR}/imgui_draw.cpp
-    ${IMGUI_DIR}/imgui_tables.cpp
-    ${IMGUI_DIR}/imgui_widgets.cpp
-    ${IMGUI_DIR}/backends/imgui_impl_sdl3.cpp
-    ${IMGUI_DIR}/backends/imgui_impl_sdlrenderer3.cpp
-    ${IMGUI_DIR}/backends/imgui_impl_sdlgpu3.cpp
-)
+if(KONCPC_BUILD_MODERN_UI)
+    set(IMGUI_SOURCES
+        ${IMGUI_DIR}/imgui.cpp
+        ${IMGUI_DIR}/imgui_draw.cpp
+        ${IMGUI_DIR}/imgui_tables.cpp
+        ${IMGUI_DIR}/imgui_widgets.cpp
+        ${IMGUI_DIR}/backends/imgui_impl_sdl3.cpp
+        ${IMGUI_DIR}/backends/imgui_impl_sdlrenderer3.cpp
+        ${IMGUI_DIR}/backends/imgui_impl_sdlgpu3.cpp
+    )
+else()
+    set(IMGUI_SOURCES "")
+endif()
 
 # ── Capsimg include directories ──────────────────────────
 set(CAPSIMG_INCLUDES
@@ -110,6 +141,13 @@ endif()
 # Bake the version into the binary.  Same compile-define pattern the
 # makefile uses (see KONCPC_VERSION above).
 target_compile_definitions(koncepcja_lib PUBLIC KONCPC_VERSION_STRING="v${PROJECT_VERSION}")
+
+# Modern-UI guard define (P1.5.1 step 4).  Source files that have
+# optional ImGui paths (currently: macos_menu.mm) check this to skip
+# ImGui-only code in headless builds.
+if(KONCPC_BUILD_MODERN_UI)
+    target_compile_definitions(koncepcja_lib PUBLIC KONCPC_MODERN_UI)
+endif()
 
 if(WIN32)
     target_compile_definitions(koncepcja_lib PUBLIC WINDOWS _WIN32_WINNT=0x0601 NOMINMAX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,9 +78,13 @@ endif()
 #
 # Keep in sync if a new UI-only TU is added; CI catches inclusion
 # regressions because the modern build still compiles them as today.
-set(MODERN_UI_SOURCES_REGEX
-    "src/(imgui_ui|imgui_ui_host|devtools_ui|command_palette|workspace_layout|video|TextEditor|LanguageDefinitions)\\.cpp$"
+# Keep this list in sync with MODERN_UI_FILES in the makefile.
+set(MODERN_UI_FILES
+    imgui_ui imgui_ui_host devtools_ui command_palette workspace_layout
+    video TextEditor LanguageDefinitions
 )
+list(JOIN MODERN_UI_FILES "|" MODERN_UI_FILES_JOINED)
+set(MODERN_UI_SOURCES_REGEX "src/(${MODERN_UI_FILES_JOINED})\\.cpp$")
 
 if(NOT KONCPC_BUILD_MODERN_UI)
     message(STATUS "KONCPC_BUILD_MODERN_UI=OFF — excluding modern UI sources from koncepcja_lib")

--- a/makefile
+++ b/makefile
@@ -198,7 +198,9 @@ HEADERS:=$(shell find $(SRCDIR) -name \*.h)
 # core can compile without the modern UI — used by the future headless
 # build (P1.5.2).  Mirror in CMakeLists.txt (KONCPC_BUILD_MODERN_UI).
 KONCPC_MODERN_UI ?= 1
-MODERN_UI_SOURCES := $(SRCDIR)/imgui_ui.cpp $(SRCDIR)/imgui_ui_host.cpp $(SRCDIR)/devtools_ui.cpp $(SRCDIR)/command_palette.cpp $(SRCDIR)/workspace_layout.cpp $(SRCDIR)/video.cpp $(SRCDIR)/TextEditor.cpp $(SRCDIR)/LanguageDefinitions.cpp
+# Keep this list in sync with MODERN_UI_FILES in CMakeLists.txt.
+MODERN_UI_FILES := imgui_ui imgui_ui_host devtools_ui command_palette workspace_layout video TextEditor LanguageDefinitions
+MODERN_UI_SOURCES := $(addprefix $(SRCDIR)/,$(addsuffix .cpp,$(MODERN_UI_FILES)))
 ifeq ($(KONCPC_MODERN_UI),1)
 COMMON_CFLAGS += -DKONCPC_MODERN_UI
 IMGUI_SOURCES:=vendor/imgui/imgui.cpp vendor/imgui/imgui_draw.cpp vendor/imgui/imgui_tables.cpp vendor/imgui/imgui_widgets.cpp vendor/imgui/backends/imgui_impl_sdl3.cpp vendor/imgui/backends/imgui_impl_sdlrenderer3.cpp vendor/imgui/backends/imgui_impl_sdlgpu3.cpp

--- a/makefile
+++ b/makefile
@@ -192,11 +192,26 @@ ifeq ($(ARCH),macos)
 MM_SOURCES:=$(shell find $(SRCDIR) -name \*.mm)
 endif
 HEADERS:=$(shell find $(SRCDIR) -name \*.h)
+
+# Modern UI gate (P1.5.1 step 4).  KONCPC_MODERN_UI=1 (default) builds the
+# Dear ImGui + SDL_GPU UI as today.  =0 excludes UI-only sources so the
+# core can compile without the modern UI — used by the future headless
+# build (P1.5.2).  Mirror in CMakeLists.txt (KONCPC_BUILD_MODERN_UI).
+KONCPC_MODERN_UI ?= 1
+MODERN_UI_SOURCES := $(SRCDIR)/imgui_ui.cpp $(SRCDIR)/imgui_ui_host.cpp $(SRCDIR)/devtools_ui.cpp $(SRCDIR)/command_palette.cpp $(SRCDIR)/workspace_layout.cpp $(SRCDIR)/video.cpp $(SRCDIR)/TextEditor.cpp $(SRCDIR)/LanguageDefinitions.cpp
+ifeq ($(KONCPC_MODERN_UI),1)
+COMMON_CFLAGS += -DKONCPC_MODERN_UI
+IMGUI_SOURCES:=vendor/imgui/imgui.cpp vendor/imgui/imgui_draw.cpp vendor/imgui/imgui_tables.cpp vendor/imgui/imgui_widgets.cpp vendor/imgui/backends/imgui_impl_sdl3.cpp vendor/imgui/backends/imgui_impl_sdlrenderer3.cpp vendor/imgui/backends/imgui_impl_sdlgpu3.cpp
+else
+$(info KONCPC_MODERN_UI=0 — excluding modern UI sources.  Full link will fail until P1.5.2 lands a headless main and an ImGui-free imgui_ui.h split.)
+SOURCES := $(filter-out $(MODERN_UI_SOURCES),$(SOURCES))
+IMGUI_SOURCES :=
+endif
+
 DEPENDS:=$(foreach file,$(SOURCES:.cpp=.d),$(shell echo "$(OBJDIR)/$(file)"))
 MM_DEPENDS:=$(foreach file,$(MM_SOURCES:.mm=.d),$(shell echo "$(OBJDIR)/$(file)"))
 OBJECTS_CPP:=$(DEPENDS:.d=.o)
 OBJECTS_MM:=$(MM_DEPENDS:.d=.o)
-IMGUI_SOURCES:=vendor/imgui/imgui.cpp vendor/imgui/imgui_draw.cpp vendor/imgui/imgui_tables.cpp vendor/imgui/imgui_widgets.cpp vendor/imgui/backends/imgui_impl_sdl3.cpp vendor/imgui/backends/imgui_impl_sdlrenderer3.cpp vendor/imgui/backends/imgui_impl_sdlgpu3.cpp
 IMGUI_OBJECTS:=$(foreach file,$(IMGUI_SOURCES:.cpp=.o),$(OBJDIR)/$(file))
 
 OBJECTS:=$(OBJECTS_CPP) $(OBJECTS_MM) $(IMGUI_OBJECTS)

--- a/src/macos_menu.mm
+++ b/src/macos_menu.mm
@@ -1,7 +1,9 @@
 #import <Cocoa/Cocoa.h>
 #include "menu_actions.h"
 #include "keyboard.h"
+#ifdef KONCPC_MODERN_UI
 #include "imgui.h"
+#endif
 #include "SDL3/SDL.h"
 #include <memory>
 
@@ -202,6 +204,7 @@ void koncpc_restore_keyboard_focus() {
 
 extern SDL_Window* mainSDLWindow;
 
+#ifdef KONCPC_MODERN_UI
 static NSWindow* nswindow_from_viewport(ImGuiViewport* vp) {
   SDL_WindowID wid = (SDL_WindowID)(uintptr_t)vp->PlatformHandle;
   SDL_Window* sdlWin = SDL_GetWindowFromID(wid);
@@ -250,6 +253,12 @@ void koncpc_order_viewports_above_main() {
     }
   }
 }
+#else  // !KONCPC_MODERN_UI
+// Headless build has no ImGui viewports — function is a stub.  Header
+// declaration (macos_menu.h) stays unchanged so callers don't need a
+// build-flag guard at every callsite.
+void koncpc_order_viewports_above_main() {}
+#endif // KONCPC_MODERN_UI
 
 // ── Dock icon ──────────────────────────────────────────────
 


### PR DESCRIPTION
Final sub-PR of **beads-1az** (P1.5.1 — Core/UI separation refactor). Adds the build gate that excludes UI-only source files when the modern Dear ImGui + SDL_GPU UI is disabled — the runway for **beads-6oa** (P1.5.2 — Headless `koncpc-core` build target).

## What

### CMake

```cmake
option(KONCPC_BUILD_MODERN_UI "Build the ImGui + SDL_GPU modern UI" ON)
```

When OFF:
- Filters `APP_SOURCES` via a regex (`imgui_ui | imgui_ui_host | devtools_ui | command_palette | workspace_layout | video | TextEditor | LanguageDefinitions`)
- Empties `IMGUI_SOURCES` so vendor/imgui sources are skipped
- Skips the `KONCPC_MODERN_UI` compile define
- Prints a `STATUS` message explaining that full link will fail until P1.5.2 lands a headless main + an ImGui-free `imgui_ui.h` split

### makefile

Same shape via `KONCPC_MODERN_UI` variable (default `1`). `make KONCPC_MODERN_UI=0` prints an `$(info …)` warning about the incomplete state, then filters sources accordingly.

### macos_menu.mm

The single Cocoa file with an ImGui-dependent helper (`koncpc_order_viewports_above_main` + `nswindow_from_viewport`) is guarded with `#ifdef KONCPC_MODERN_UI / #else stub`. Header declaration stays unchanged so callers don't need build-flag guards — the function just becomes a no-op in headless builds.

## Files NOT excluded

| File | Why |
|------|-----|
| `src/video_gpu.cpp` | No direct ImGui deps; `kon_cpc_ja.cpp`'s `video_gpu_shutdown()` safety-net call still wants the symbol |
| `src/macos_menu.mm` | Partial guard above; most of the file is pure Cocoa menu setup that's still useful in a headless macOS build |

## What this PR does NOT do

- **Doesn't make MODERN_UI=OFF link cleanly.** `kon_cpc_ja.cpp` still includes `imgui_ui.h` for the `imgui_state` global struct, and that header declares functions that no longer have definitions when UI sources are excluded. P1.5.2 either splits `imgui_ui.h` or moves `imgui_state` into a headless-safe header.
- **No CI matrix entry for MODERN_UI=OFF.** The gate is here for P1.5.2 to consume; a CI verifier can come with that work or as a follow-up.

## Verification

- `make -j ARCH=macos test_runner` → clean build with **all UI sources compiled as today** (verified the linker line still contains imgui_ui.o, devtools_ui.o, etc.)
- `./test_runner --gtest_shuffle` → **1114/1114 pass**, 2 pre-existing `RamExpansion` skips unchanged

## P1.5.1 status (closes the phase)

This closes beads-1az's 4-sub-PR sequence:

| # | Title | Status |
|---|-------|--------|
| #124 | IUiHost interface + NullUiHost | merged |
| #125 | Event pump routed through ui_host() | merged |
| #126 | Drag-drop toasts routed | merged |
| **this** | KONCPC_BUILD_MODERN_UI build flag | here |

Next ready work: **beads-6oa** (P1.5.2 — Headless build target), which will consume the `KONCPC_BUILD_MODERN_UI=OFF` gate to ship the `koncpc-core` binary.
