### PR TITLE
refactor(ui): split imgui_state.h from imgui_ui.h — P1.5.2 step 1

### DIFF
--- a/src/imgui_state.cpp
+++ b/src/imgui_state.cpp
@@ -1,0 +1,14 @@
+// Definition of the process-wide `imgui_state` singleton.
+//
+// Lives in its own TU (not imgui_ui.cpp) so the symbol is present in
+// MODERN_UI=ON and OFF builds alike: this file is unconditionally part
+// of `koncepcja_lib`, while imgui_ui.cpp is excluded when MODERN_UI=OFF.
+//
+// The struct itself is a pure data container — no ImGui types, no
+// rendering — so it compiles cleanly without the UI sources.  Telemetry
+// writers in the core (kon_cpc_ja.cpp, z80.cpp, …) and the text IPC
+// server read/write this struct directly.
+
+#include "imgui_state.h"
+
+ImGuiUIState imgui_state;

--- a/src/imgui_state.h
+++ b/src/imgui_state.h
@@ -1,0 +1,148 @@
+#ifndef IMGUI_STATE_H
+#define IMGUI_STATE_H
+
+// Headless-safe data side of the modern UI.
+//
+// Background: the modern UI (ImGui + SDL_GPU) and the emulator core both
+// touch a process-wide "UIState" struct.  The core writes telemetry into
+// it (frame_time_*, audio_*, drive_*_led, …); the UI reads telemetry to
+// render and writes back request flags (show_devtools, …).
+//
+// Today the struct lived in `imgui_ui.h` next to function declarations
+// that pull ImGui types into every translation unit that includes the
+// header.  For the headless build target (P1.5.2) the core TUs need
+// the *struct* but must not see UI function declarations, otherwise
+// linker tries to resolve them in builds where imgui_ui.cpp is excluded.
+//
+// This header is the headless-safe extraction: just the POD-ish state +
+// the extern.  No ImGui includes.  `imgui_ui.h` now `#include`s this
+// header for backward compatibility, so modern-UI translation units keep
+// compiling unchanged.
+//
+// Definition of the singleton `imgui_state` lives in `imgui_state.cpp`,
+// which is unconditionally compiled into `koncepcja_lib` (both MODERN_UI
+// ON and OFF), so the symbol is always resolvable.
+
+#include <string>
+#include <vector>
+#include <deque>
+#include "koncepcja.h"
+
+enum class FileDialogAction {
+  None,
+  LoadDiskA, LoadDiskB, SaveDiskA, SaveDiskB,
+  LoadSnapshot, SaveSnapshot,
+  LoadTape, LoadCartridge,
+  LoadROM,
+  LoadDiskA_LED, LoadDiskB_LED,
+  LoadTape_LED,
+  SelectM4SDFolder,
+  SavePlotterSVG
+};
+
+struct ImGuiUIState {
+  // Dialog visibility flags
+  bool show_menu = false;
+  bool show_options = false;
+  bool show_devtools = false;
+  bool show_memory_tool = false;
+  bool show_vkeyboard = false;
+  bool show_about = false;
+  bool show_quit_confirm = false;
+  bool show_serial_terminal = false;
+  bool show_plotter_preview = false;
+
+  // Deferred video reinit (set in Options, handled after ImGui frame)
+  bool video_reinit_pending = false;
+
+  // Menu was just opened (for first-frame focus)
+  bool menu_just_opened = false;
+
+  // Top bar state
+  std::string topbar_fps;
+  bool drive_a_led = false;
+  bool drive_b_led = false;
+
+  // Frame timing measurement (updated each second, values in microseconds)
+  float frame_time_avg_us = 0.0f;
+  float frame_time_min_us = 0.0f;
+  float frame_time_max_us = 0.0f;
+  float display_time_avg_us = 0.0f;
+  float sleep_time_avg_us = 0.0f;
+  float z80_time_avg_us = 0.0f;
+
+  // Audio diagnostics (updated each second)
+  int audio_underruns = 0;           // times SDL queue was empty when we pushed
+  int audio_near_underruns = 0;      // times queue was below 1 buffer
+  int audio_pushes = 0;              // total pushes this second
+  float audio_queue_avg_ms = 0.0f;   // average queue depth in ms
+  float audio_queue_min_ms = 0.0f;   // minimum queue depth in ms
+  float audio_push_interval_max_us = 0.0f; // longest gap between pushes
+
+  // Options dialog state
+  t_CPC old_cpc_settings;
+
+  // Memory tool input buffers
+  char mem_poke_addr[8] = "";
+  char mem_poke_val[8] = "";
+  char mem_display_addr[8] = "";
+  char mem_filter_val[8] = "";
+  int mem_bytes_per_line = 16;
+  int mem_display_value = -1;
+  int mem_filter_value = -1;
+
+  // Eject confirmation
+  int eject_confirm_drive = -1; // -1=none, 0=A, 1=B
+  bool eject_confirm_tape = false;
+
+  // Tape block index (built on tape load)
+  std::vector<byte*> tape_block_offsets;
+  int tape_current_block = 0;
+
+  // File dialog async state
+  FileDialogAction pending_dialog = FileDialogAction::None;
+  std::string pending_dialog_result;
+  int pending_rom_slot = -1;
+
+  // Tape waveform oscilloscope
+  static constexpr int TAPE_WAVE_SAMPLES = 128;
+  byte tape_wave_buf[TAPE_WAVE_SAMPLES] = {};   // raw pulse level
+  int  tape_wave_head = 0;
+
+  int  tape_wave_mode = 0; // 0=pulse, 1=decoded
+
+  // Decoded bits ring buffer (written by Tape_ReadDataBit)
+  static constexpr int TAPE_DECODED_SAMPLES = 200;
+  byte tape_decoded_buf[TAPE_DECODED_SAMPLES] = {};
+  int  tape_decoded_head = 0;
+
+  // Virtual keyboard state
+  bool vkeyboard_caps_lock = false;      // CAPS LOCK - sticky toggle
+  bool vkeyboard_shift_next = false;     // SHIFT - one-shot, clears after 1 char
+  bool vkeyboard_ctrl_next = false;      // CTRL - one-shot, clears after 1 char
+
+  // Docked mode: CPC Screen focus tracking for keyboard routing
+  bool cpc_screen_focused = false;       // true when CPC Screen tab is the focused window
+  bool request_cpc_screen_focus = false;  // set by event loop on app focus gain
+
+  // Layout dropdown (topbar)
+  bool show_layout_dropdown = false;
+
+  // Toast notification system
+  enum class ToastLevel { Info, Success, Error };
+  struct Toast {
+    std::string message;
+    ToastLevel level = ToastLevel::Info;
+    float timer = 0.0f;       // seconds remaining
+    float initial = 0.0f;     // initial duration (for fade calc)
+  };
+  std::deque<Toast> toasts;   // rendered bottom-up, newest last
+  static constexpr int MAX_TOASTS = 4;
+  static constexpr float TOAST_DURATION = 3.5f;
+  static constexpr float TOAST_FADE_TIME = 0.5f;
+
+};
+
+extern ImGuiUIState imgui_state;
+
+#endif // IMGUI_STATE_H

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -59,7 +59,9 @@ extern byte *pbTapeBlock;
 extern int iTapeCycleCount;
 extern dword dwTapeZeroPulseCycles;
 
-ImGuiUIState imgui_state;
+// `imgui_state` singleton lives in src/imgui_state.cpp so the symbol is
+// present in both MODERN_UI=ON and OFF builds — the core writes telemetry
+// into it from headless TUs that don't link imgui_ui.cpp.
 
 // Forward declarations
 static void imgui_render_menubar();

--- a/src/imgui_ui.h
+++ b/src/imgui_ui.h
@@ -1,127 +1,18 @@
 #ifndef IMGUI_UI_H
 #define IMGUI_UI_H
 
-#include <string>
-#include <vector>
-#include <deque>
-#include "koncepcja.h"
+// Modern-UI public surface — function declarations for the ImGui +
+// SDL_GPU build.  When KONCPC_BUILD_MODERN_UI=OFF the implementations
+// in imgui_ui.cpp / devtools_ui.cpp / video.cpp are excluded, so this
+// header is only included from translation units that themselves are
+// part of the modern-UI compile.
+//
+// The data side of the UI (the `imgui_state` singleton + telemetry
+// fields the core writes into) lives in `imgui_state.h`, which is
+// headless-safe.  This header re-exports `imgui_state.h` so existing
+// modern-UI callers keep compiling unchanged.
 
-enum class FileDialogAction {
-  None,
-  LoadDiskA, LoadDiskB, SaveDiskA, SaveDiskB,
-  LoadSnapshot, SaveSnapshot,
-  LoadTape, LoadCartridge,
-  LoadROM,
-  LoadDiskA_LED, LoadDiskB_LED,
-  LoadTape_LED,
-  SelectM4SDFolder,
-  SavePlotterSVG
-};
-
-struct ImGuiUIState {
-  // Dialog visibility flags
-  bool show_menu = false;
-  bool show_options = false;
-  bool show_devtools = false;
-  bool show_memory_tool = false;
-  bool show_vkeyboard = false;
-  bool show_about = false;
-  bool show_quit_confirm = false;
-  bool show_serial_terminal = false;
-  bool show_plotter_preview = false;
-
-  // Deferred video reinit (set in Options, handled after ImGui frame)
-  bool video_reinit_pending = false;
-
-  // Menu was just opened (for first-frame focus)
-  bool menu_just_opened = false;
-
-  // Top bar state
-  std::string topbar_fps;
-  bool drive_a_led = false;
-  bool drive_b_led = false;
-
-  // Frame timing measurement (updated each second, values in microseconds)
-  float frame_time_avg_us = 0.0f;
-  float frame_time_min_us = 0.0f;
-  float frame_time_max_us = 0.0f;
-  float display_time_avg_us = 0.0f;
-  float sleep_time_avg_us = 0.0f;
-  float z80_time_avg_us = 0.0f;
-
-  // Audio diagnostics (updated each second)
-  int audio_underruns = 0;           // times SDL queue was empty when we pushed
-  int audio_near_underruns = 0;      // times queue was below 1 buffer
-  int audio_pushes = 0;              // total pushes this second
-  float audio_queue_avg_ms = 0.0f;   // average queue depth in ms
-  float audio_queue_min_ms = 0.0f;   // minimum queue depth in ms
-  float audio_push_interval_max_us = 0.0f; // longest gap between pushes
-
-  // Options dialog state
-  t_CPC old_cpc_settings;
-
-  // Memory tool input buffers
-  char mem_poke_addr[8] = "";
-  char mem_poke_val[8] = "";
-  char mem_display_addr[8] = "";
-  char mem_filter_val[8] = "";
-  int mem_bytes_per_line = 16;
-  int mem_display_value = -1;
-  int mem_filter_value = -1;
-
-  // Eject confirmation
-  int eject_confirm_drive = -1; // -1=none, 0=A, 1=B
-  bool eject_confirm_tape = false;
-
-  // Tape block index (built on tape load)
-  std::vector<byte*> tape_block_offsets;
-  int tape_current_block = 0;
-
-  // File dialog async state
-  FileDialogAction pending_dialog = FileDialogAction::None;
-  std::string pending_dialog_result;
-  int pending_rom_slot = -1;
-
-  // Tape waveform oscilloscope
-  static constexpr int TAPE_WAVE_SAMPLES = 128;
-  byte tape_wave_buf[TAPE_WAVE_SAMPLES] = {};   // raw pulse level
-  int  tape_wave_head = 0;
-
-  int  tape_wave_mode = 0; // 0=pulse, 1=decoded
-
-  // Decoded bits ring buffer (written by Tape_ReadDataBit)
-  static constexpr int TAPE_DECODED_SAMPLES = 200;
-  byte tape_decoded_buf[TAPE_DECODED_SAMPLES] = {};
-  int  tape_decoded_head = 0;
-
-  // Virtual keyboard state
-  bool vkeyboard_caps_lock = false;      // CAPS LOCK - sticky toggle
-  bool vkeyboard_shift_next = false;     // SHIFT - one-shot, clears after 1 char
-  bool vkeyboard_ctrl_next = false;      // CTRL - one-shot, clears after 1 char
-
-  // Docked mode: CPC Screen focus tracking for keyboard routing
-  bool cpc_screen_focused = false;       // true when CPC Screen tab is the focused window
-  bool request_cpc_screen_focus = false;  // set by event loop on app focus gain
-
-  // Layout dropdown (topbar)
-  bool show_layout_dropdown = false;
-
-  // Toast notification system
-  enum class ToastLevel { Info, Success, Error };
-  struct Toast {
-    std::string message;
-    ToastLevel level = ToastLevel::Info;
-    float timer = 0.0f;       // seconds remaining
-    float initial = 0.0f;     // initial duration (for fade calc)
-  };
-  std::deque<Toast> toasts;   // rendered bottom-up, newest last
-  static constexpr int MAX_TOASTS = 4;
-  static constexpr float TOAST_DURATION = 3.5f;
-  static constexpr float TOAST_FADE_TIME = 0.5f;
-
-};
-
-extern ImGuiUIState imgui_state;
+#include "imgui_state.h"
 
 void imgui_init_ui();
 void imgui_render_ui();

--- a/src/koncepcja_ipc_server.cpp
+++ b/src/koncepcja_ipc_server.cpp
@@ -3,7 +3,7 @@
 #include "autotype.h"
 #include "gfx_finder.h"
 #include "search_engine.h"
-#include "imgui_ui.h"
+#include "imgui_state.h"
 // `video.h` (defining video_plugin_list) is already included via the
 // project-internal include block below.
 

--- a/src/tape.cpp
+++ b/src/tape.cpp
@@ -25,7 +25,7 @@
 #include "koncepcja.h"
 #include "tape.h"
 #include "z80.h"
-#include "imgui_ui.h"
+#include "imgui_state.h"
 
 #define TAPE_PILOT_STAGE 1
 #define TAPE_SYNC_STAGE 2

--- a/src/z80.cpp
+++ b/src/z80.cpp
@@ -30,7 +30,7 @@
 #include "tape.h"
 #include "z80.h"
 #include "asic.h"
-#include "imgui_ui.h"
+#include "imgui_state.h"
 #include "trace.h"
 #include "koncepcja_ipc_server.h"
 #include "expr_parser.h"

--- a/test/tape.cpp
+++ b/test/tape.cpp
@@ -2,7 +2,7 @@
 #include <vector>
 #include "koncepcja.h"
 #include "tape.h"
-#include "imgui_ui.h"
+#include "imgui_state.h"
 
 // External globals from tape.cpp
 extern byte bTapeLevel;


### PR DESCRIPTION
## Summary

First sub-PR of P1.5.2 (beads-6oa) — preparing the headless build target.

`imgui_ui.h` previously mixed the **data side** of the UI (the `ImGuiUIState` singleton, telemetry fields the core writes into, the file dialog enum) with **declarations of UI-only functions** (`imgui_init_ui`, `imgui_render_ui`, `imgui_topbar_height`, toasts, …). For the headless build the core TUs need the *struct* but must not see UI function declarations, otherwise the linker fails to resolve them when `imgui_ui.cpp` / `devtools_ui.cpp` / `video.cpp` are excluded.

Extract the headless-safe parts into a new `src/imgui_state.h`:
- `FileDialogAction` enum
- `ImGuiUIState` struct (POD-ish — only `<string>` / `<vector>` / `<deque>` standard types)
- `extern ImGuiUIState imgui_state;`

Move the singleton's definition into its own TU `src/imgui_state.cpp` so the symbol is present in `koncepcja_lib` regardless of `KONCPC_BUILD_MODERN_UI`. `imgui_ui.h` now `#include`s the new header, so modern-UI callers keep compiling unchanged.

Switch the four headless-only consumers — `koncepcja_ipc_server.cpp`, `tape.cpp`, `z80.cpp`, `test/tape.cpp` — to include `imgui_state.h` instead of `imgui_ui.h`. `test/ui_state_test.cpp` keeps `imgui_ui.h` (it calls `imgui_close_menu` + `imgui_toast_info`).

## Scope

- Pure refactor — no behaviour change.
- `MODERN_UI=ON` build is **bit-identical** to before this PR.
- `MODERN_UI=OFF` link still fails — that's step 2 (stub the remaining UI calls in `kon_cpc_ja.cpp`'s main loop).
- No new CMake options yet.

## Test plan

- [x] `make -j ARCH=macos` clean build
- [x] `make ARCH=macos unit_test` — 1114/1114 pass, same 2 pre-existing `RamExpansion` skips
- [ ] CI green on Linux, MacOS, all 6 MSVC configurations, Coverage

## Sub-PR roadmap (P1.5.2)

1. **(this PR)** Header split — `imgui_state.h` extracted
2. Stub UI calls in `kon_cpc_ja.cpp` so MODERN_UI=OFF link works (no executable yet)
3. Add `koncpc-core` executable + `KONCPC_BUILD_HEADLESS=OFF` CMake option
4. CI integration — headless build job + smoke test

bd: beads-6oa