### PR TITLE
fix(ipc): gfx palette printed red/blue swapped

### DIFF
--- a/src/koncepcja_ipc_server.cpp
+++ b/src/koncepcja_ipc_server.cpp
@@ -3596,14 +3596,25 @@ std::string handle_command(const std::string& line) {
       }
     }
     if (parts[1] == "palette") {
-      // gfx palette — show current palette as RGBA hex
+      // gfx palette — show current palette as #RRGGBBAA hex.
+      // gfx_get_palette_rgba() packs each colour little-endian as
+      // (r | g<<8 | b<<16 | a<<24), which is correct for the SDL RGBA32
+      // surface used by `gfx decode`. Printing that uint32 with %08X, however,
+      // emits it big-end-first (#AABBGGRR), transposing the red and blue
+      // channels in the text. Unpack the bytes and print them in true
+      // R,G,B,A order so the hex matches what the screen actually renders.
       uint32_t palette[16];
       gfx_get_palette_rgba(palette, 16);
       std::ostringstream resp;
       resp << "OK\n";
       for (int i = 0; i < 16; i++) {
+        uint32_t c = palette[i];
+        unsigned r =  c        & 0xFF;
+        unsigned g = (c >>  8) & 0xFF;
+        unsigned b = (c >> 16) & 0xFF;
+        unsigned a = (c >> 24) & 0xFF;
         char buf[32];
-        snprintf(buf, sizeof(buf), "%2d: #%08X\n", i, palette[i]);
+        snprintf(buf, sizeof(buf), "%2d: #%02X%02X%02X%02X\n", i, r, g, b, a);
         resp << buf;
       }
       return resp.str();


### PR DESCRIPTION
## Problem
`gfx palette` reported colours that **disagree with what the emulator actually renders** — red and blue come out swapped.

`gfx_get_palette_rgba()` packs each colour little-endian as `(r | g<<8 | b<<16 | a<<24)`, which is correct for the SDL RGBA32 surface that `gfx decode` uses. But the `gfx palette` command printed that `uint32` with `%08X`, which emits it big-end-first as `#AABBGGRR` — transposing red and blue in the text and not matching the documented "RGBA hex".

So a bright-blue pen printed as `#FFFF0000` (looks yellow), a bright-yellow pen as `#00FFFFFF` (looks cyan), etc. Anyone reading the dump as `#RRGGBB(AA)` (the documented format) gets R and B swapped. The renderer itself is correct — only this debug readout was wrong.

## Fix
Unpack the bytes and print them in true `R, G, B, A` order (`#RRGGBBAA`). No change to `gfx_get_palette_rgba()` — its packing is correct for the decode/render path; only the command's formatting is corrected.

## Verification
With a known game palette loaded:

| pen | colour | before (`#%08X`) | after |
|-----|--------|------------------|-------|
| 2 | bright red | `#FF0000FF` | `#FF0000FF` |
| 3 | bright blue | `#FFFF0000` (looked yellow) | `#0000FFFF` |
| 5 | bright yellow | `#00FFFFFF` (looked cyan) | `#FFFF00FF` |
| 6 | bright cyan | `#FFFFFF00` | `#00FFFFFF` |
| 7 | pink | `#FF7F7FFF` | `#FF7F7FFF` |

After the fix every entry matches the rendered display and cpctelera's measured Gate Array colour table. Full test suite passes (1116/1116).