### PR TITLE
fix(crtc): prevent RendBuff overrun corrupting render pointers (SIGSEGV in render32bpp_doubleY)

### DIFF
--- a/src/crtc.cpp
+++ b/src/crtc.cpp
@@ -68,7 +68,14 @@ byte PosShift, HorzChar, HorzMax;
 dword *ModeMaps[4];
 dword *ModeMap;
 byte HorzPix[49];
-byte RendBuff[800];
+// Logical render width: 49 CRTC chars × 16 bytes, rendered from RendStart=&RendBuff[16].
+// REND_BUFF_MARGIN is slack so that even a bounded prerender overrun (e.g. a CRTC
+// program that stretches a scanline until the byte-wide HorzChar counter wraps before
+// a monitor HSYNC resets RendPos) cannot reach the adjacent RendWid/RendOut/RendStart/
+// RendPos pointers and corrupt them. See the bounds guard in crtc_cycle(). (beads-33f)
+static constexpr int REND_BUFF_USABLE = 800;
+static constexpr int REND_BUFF_MARGIN = 64;
+byte RendBuff[REND_BUFF_USABLE + REND_BUFF_MARGIN];
 byte *RendWid, *RendOut;
 dword *RendStart, *RendPos;
 
@@ -1075,7 +1082,15 @@ void crtc_cycle(int repeat_count)
 {
    while (repeat_count) {
       if (VDU.flag_drawing && !CPC.skip_rendering) { // are we within the rendering area?
-         if (HorzChar < HorzMax) { // below horizontal cut-off?
+         // HorzChar < HorzMax caps a normal scanline to 48/49 chars, but HorzChar is a
+         // byte: a CRTC program can stretch a scanline past 256 char-cycles before the
+         // monitor HSYNC resets RendPos, wrapping HorzChar back under HorzMax so rendering
+         // resumes with the buffers already full. The pointer guards below are wrap-immune:
+         // RendWid must stay within HorzPix, and RendPos must leave room for one full
+         // 4-dword prerender write inside the usable RendBuff region. (beads-33f)
+         if (HorzChar < HorzMax
+             && RendWid < &HorzPix[sizeof(HorzPix)]
+             && RendPos <= reinterpret_cast<dword *>(&RendBuff[REND_BUFF_USABLE]) - 4) { // below horizontal cut-off?
             if (flags1.combined != LastPreRend) {
                set_prerender(); // change pre-renderer if necessary
             }

--- a/src/crtc.cpp
+++ b/src/crtc.cpp
@@ -75,7 +75,7 @@ byte HorzPix[49];
 // RendPos pointers and corrupt them. See the bounds guard in crtc_cycle(). (beads-33f)
 static constexpr int REND_BUFF_USABLE = 800;
 static constexpr int REND_BUFF_MARGIN = 64;
-byte RendBuff[REND_BUFF_USABLE + REND_BUFF_MARGIN];
+alignas(dword) byte RendBuff[REND_BUFF_USABLE + REND_BUFF_MARGIN]; // cast to dword* in (pre)render
 byte *RendWid, *RendOut;
 dword *RendStart, *RendPos;
 
@@ -1090,7 +1090,7 @@ void crtc_cycle(int repeat_count)
          // 4-dword prerender write inside the usable RendBuff region. (beads-33f)
          if (HorzChar < HorzMax
              && RendWid < &HorzPix[sizeof(HorzPix)]
-             && RendPos <= reinterpret_cast<dword *>(&RendBuff[REND_BUFF_USABLE]) - 4) { // below horizontal cut-off?
+             && reinterpret_cast<byte *>(RendPos) <= &RendBuff[REND_BUFF_USABLE - 16]) { // below horizontal cut-off? (-16 = one 4-dword prerender write)
             if (flags1.combined != LastPreRend) {
                set_prerender(); // change pre-renderer if necessary
             }

--- a/src/crtc.cpp
+++ b/src/crtc.cpp
@@ -21,6 +21,7 @@
 */
 
 #include <math.h>
+#include <iterator> // std::end
 
 #include "koncepcja.h"
 #include "crtc.h"
@@ -75,6 +76,7 @@ byte HorzPix[49];
 // RendPos pointers and corrupt them. See the bounds guard in crtc_cycle(). (beads-33f)
 static constexpr int REND_BUFF_USABLE = 800;
 static constexpr int REND_BUFF_MARGIN = 64;
+static constexpr int MAX_PRERENDER_WRITE_BYTES = 16; // a full prerender writes 4 dwords
 alignas(dword) byte RendBuff[REND_BUFF_USABLE + REND_BUFF_MARGIN]; // cast to dword* in (pre)render
 byte *RendWid, *RendOut;
 dword *RendStart, *RendPos;
@@ -1089,8 +1091,8 @@ void crtc_cycle(int repeat_count)
          // RendWid must stay within HorzPix, and RendPos must leave room for one full
          // 4-dword prerender write inside the usable RendBuff region. (beads-33f)
          if (HorzChar < HorzMax
-             && RendWid < &HorzPix[sizeof(HorzPix)]
-             && reinterpret_cast<byte *>(RendPos) <= &RendBuff[REND_BUFF_USABLE - 16]) { // below horizontal cut-off? (-16 = one 4-dword prerender write)
+             && RendWid < std::end(HorzPix)
+             && reinterpret_cast<byte *>(RendPos) <= &RendBuff[REND_BUFF_USABLE - MAX_PRERENDER_WRITE_BYTES]) { // below horizontal cut-off?
             if (flags1.combined != LastPreRend) {
                set_prerender(); // change pre-renderer if necessary
             }


### PR DESCRIPTION
## Crash

`EXC_BAD_ACCESS (SIGSEGV)` reading `0x0011111111111111` in the Z80 render thread:

```
render32bpp_doubleY()   ← byte bCount = *RendWid++;   RendWid == 0x0011111111111111
crtc_cycle(int)
z80_thread_main()       kon_cpc_ja.cpp:3681
```

The faulting instruction is the very first load in the function (`ldrb w14, [x9]` with `x9` = the `RendWid` global), so the **global pointer `RendWid` itself was overwritten** with a `0x11`-byte fill — not walked off a valid array.

## Root cause

`prerender_sync()` fills the render buffer with `0x11111111` (border uses `0x10101010`) via the `RendPos` write cursor, 4 dwords (16 bytes) per char. `RendBuff[800]` holds **exactly** 49 chars from `RendStart = &RendBuff[16]` — zero margin — and the symbol table shows `RendWid`/`RendOut`/`RendStart`/`RendPos` packed **immediately after** `RendBuff` (7 bytes of slack).

`HorzChar`/`HorzMax` are `byte`. The render guard `HorzChar < HorzMax` caps a normal scanline at 48/49 chars, but `RendPos` is only reset at the monitor HSYNC. A CRTC program that stretches a scanline past 256 char-cycles before that HSYNC wraps `HorzChar` (255→0) back under `HorzMax`, so prerendering **resumes with the buffer already full** and overruns it — writing the `0x11111111` fill straight over the `RendWid` pointer. The next frame faults on `*RendWid++`.

(Diagnosis confirmed by disassembling the crashing binary; its UUID matches the build exactly.)

## Fix

Add **wrap-immune pointer bounds guards** in `crtc_cycle()`:
- `RendWid` must stay within `HorzPix`
- `RendPos` must leave room for one full 4-dword prerender write inside the usable `RendBuff` region

Plus a `RendBuff` margin (`REND_BUFF_MARGIN`) as defense-in-depth so any bounded overrun can never reach the adjacent pointer globals.

Normal frames are unaffected — all 49 chars still render; only the pathological overrun is clamped (the clamped region is off-screen garbage).

## Testing

- Builds clean (`scripts/build-macos.sh`), no new warnings.
- Full unit suite green: 1116/1116 (2 pre-existing skips).
- Confirmed via symbol table that `RendWid` now sits 64+ bytes past the usable buffer instead of 7.

Closes beads-33f.
