### PR TITLE
refactor(memory): Phase 6+7 — CPU-view accessor with MF2/ASIC intercepts

### DIFF
--- a/docs/core-refactor-roadmap.md
+++ b/docs/core-refactor-roadmap.md
@@ -1,0 +1,50 @@
+# Core refactor roadmap
+
+Summary of the MemoryBus/IoBus/CpcMachine refactor and follow-up options for the "for now" memory layers.
+
+## Completed (Phases 1–5)
+
+| Phase | Description |
+|-------|-------------|
+| 1 | **CpcMachine** — Non-owning aggregate of core globals (Z80, drives, etc.). Merged in PR #48. |
+| 2 | **MemoryBus + IoBus** — Thin non-owning wrappers over `membank_read`/`membank_write` and `io_dispatch_*`. Merged in PR #49. |
+| 3 | **Wire hot paths** — Z80 raw memory uses `g_memory_bus.read_raw`/`write_raw`; IN/OUT use `g_io_bus.in`/`out`. Merged in PR #49. |
+| 4 | **Route remaining memory** — `z80_read_mem_via_write_bank` and ASIC DMA/register writes go through `g_memory_bus`. No direct `membank_*` access for data. |
+| 5 | **Centralize bank switching** — `memory_set_read_bank()` / `memory_set_write_bank()`; only `kon_cpc_ja.cpp` touches the bank arrays. IPC and imgui use the setters. |
+
+## Current "for now" state: memory layers in z80.cpp
+
+`MemoryBus` is intentionally **raw banked access only**. It does not know about:
+
+- **SmartWatch** — Intercepts upper ROM reads (0xC000+) when enabled; implemented in `read_mem_no_watchpoint()` in z80.cpp after `g_memory_bus.read_raw()`.
+- **Watchpoints** — Read/write breakpoints with conditions; implemented in `read_mem()` / `write_mem()` wrapping the no-watchpoint path.
+- **ASIC register page** — Writes to 0x4000–0x7FFF when register page is on; handled in `write_mem()` before `write_mem_no_watchpoint()`.
+- **Multiface II RAM** — Writes to 0x2000–0x3FFF when MF2 is active go to MF2 SRAM; handled in `write_mem()`.
+
+So today:
+
+- **Single layering point**: z80.cpp `read_mem` / `read_mem_no_watchpoint` and `write_mem` / `write_mem_no_watchpoint`.
+- **Public API**: `z80_read_mem` / `z80_write_mem` call the no-watchpoint path (so they see SmartWatch on read; they do **not** go through watchpoints, MF2 RAM redirect, or ASIC register page).
+- **IPC / DevTools**: Use `z80_read_mem` / `z80_write_mem` (and `z80_read_mem_via_write_bank` for raw write-bank view). So they get SmartWatch on read but raw bus for the write path (no MF2/ASIC redirect there).
+
+## Planned follow-up: Phase 6+ (memory layers)
+
+We aim for **Option B** then **Option C** as a **sequence**: B centralizes the layered accessor logic in one place; C turns that into a first-class type (LayeredMemory / MemoryController) on CpcMachine. They are not alternatives—C builds on B.
+
+### Phase 6 (Option B): Shared "CPU view" accessor ✅
+
+- `z80_cpu_write_mem()` now applies MF2 RAM redirect + ASIC register page + IPC events (same as `write_mem()` but without watchpoints).
+- `z80_cpu_read_mem()` applies SmartWatch on upper ROM reads (unchanged, was already correct).
+- `LayeredMemory` facade updated to document the correct semantics.
+- IPC `mem write` commands and DevTools memory poke can use `z80_cpu_write_mem()` to get proper device intercept behavior.
+
+### Phase 7 (Option C): LayeredMemory / MemoryController type ✅
+
+- `LayeredMemory` exists at `src/layered_memory.h` — thin facade over MemoryBus + device intercepts.
+- Lives on `CpcMachine` as `g_machine.memory` (`src/cpc_machine.h:24`).
+- `read_cpu()`/`write_cpu()` provide full device layering (SmartWatch/MF2/ASIC) without watchpoints.
+- Callers can migrate from `z80_cpu_read_mem`/`z80_cpu_write_mem` to `g_machine.memory.read_cpu()`/`write_cpu()` as cleanup.
+
+- A small wrapper that holds a `MemoryBus&` and optional hooks (SmartWatch, watchpoints, MF2, ASIC) and exposes `read(addr)` / `write(addr, val)`.
+- Could live on `CpcMachine` so tools take a machine and get consistent memory semantics.
+- Sets up for multiple machines or testing with a different bus/layers.

--- a/docs/core-refactor-roadmap.md
+++ b/docs/core-refactor-roadmap.md
@@ -44,7 +44,3 @@ We aim for **Option B** then **Option C** as a **sequence**: B centralizes the l
 - Lives on `CpcMachine` as `g_machine.memory` (`src/cpc_machine.h:24`).
 - `read_cpu()`/`write_cpu()` provide full device layering (SmartWatch/MF2/ASIC) without watchpoints.
 - Callers can migrate from `z80_cpu_read_mem`/`z80_cpu_write_mem` to `g_machine.memory.read_cpu()`/`write_cpu()` as cleanup.
-
-- A small wrapper that holds a `MemoryBus&` and optional hooks (SmartWatch, watchpoints, MF2, ASIC) and exposes `read(addr)` / `write(addr, val)`.
-- Could live on `CpcMachine` so tools take a machine and get consistent memory semantics.
-- Sets up for multiple machines or testing with a different bus/layers.

--- a/src/layered_memory.h
+++ b/src/layered_memory.h
@@ -11,13 +11,16 @@
 // global accessors and MemoryBus. It just forwards calls.
 struct LayeredMemory {
   // Direct debug view (old IPC behavior):
-  // - read: SmartWatch on upper ROM, no watchpoints
-  // - write: raw MemoryBus, no watchpoints
+  // - read: SmartWatch on upper ROM, no watchpoints, no MF2/ASIC
+  // - write: raw MemoryBus, no watchpoints, no MF2/ASIC
   inline byte read_direct(word addr) const { return z80_read_mem(addr); }
 
   inline void write_direct(word addr, byte v) const { z80_write_mem(addr, v); }
 
-  // CPU view: full layering (watchpoints + SmartWatch/MF2/ASIC + bus).
+  // CPU view: full device layering without watchpoints.
+  // - read: SmartWatch on upper ROM, raw bus otherwise
+  // - write: MF2 RAM redirect + ASIC register page + bus + IPC events
+  // Safe for IPC and UI — won't trigger watchpoint hits.
   inline byte read_cpu(word addr) const { return z80_cpu_read_mem(addr); }
 
   inline void write_cpu(word addr, byte v) const { z80_cpu_write_mem(addr, v); }

--- a/src/z80.cpp
+++ b/src/z80.cpp
@@ -1083,7 +1083,19 @@ void z80_write_mem(word addr, byte val) { write_mem_no_watchpoint(addr, val); }
 byte z80_cpu_read_mem(word addr) { return read_mem_no_watchpoint(addr); }
 
 void z80_cpu_write_mem(word addr, byte val) {
+  // CPU view: MF2 RAM redirect + ASIC register page + bus + IPC events
+  // (same as write_mem() but without watchpoint checking)
+  if ((dwMF2Flags & MF2_ACTIVE) && pbMF2ROM && addr >= 0x2000 &&
+      addr < 0x4000) {
+    pbMF2ROM[addr] = val;
+    ipc_check_mem_write_events(addr, val);
+    return;
+  }
+  if (GateArray.registerPageOn) {
+    if (!asic_register_page_write(addr, val)) return;
+  }
   write_mem_no_watchpoint(addr, val);
+  ipc_check_mem_write_events(addr, val);
 }
 
 byte z80_read_mem_via_write_bank(word addr) {

--- a/test/asic.cpp
+++ b/test/asic.cpp
@@ -190,4 +190,26 @@ TEST_F(AsicTest, AsicDMACycleWriteBackDCSR) {
   EXPECT_EQ(1, *(membank_write[1] + 0x2c0f));
 }
 
+TEST_F(AsicTest, AsicDMABankBoundaryRead) {
+  // When source_address is at 0x3FFF (last byte of bank 0), the instruction
+  // spans two banks: low byte from bank 0 offset 0x3FFF, high byte from
+  // bank 1 offset 0x0000. Before the fix, addr+1=0x4000 was OOB.
+  std::vector<byte> bank0(0x4000, 0);
+  std::vector<byte> bank1(0x4000, 0);
+  bank0[0x3FFF] = 0x34;  // low byte of instruction
+  bank1[0x0000] = 0x12;  // high byte of instruction (LOAD R4, 0x12)
+  membank_config[0][0] = &bank0[0];
+  membank_config[0][1] = &bank1[0];
+  std::vector<byte> write_bank(0x4000, 0);
+  membank_write[1] = &write_bank[0];
+
+  GateArray.RAM_config = 0;
+  asic_reset();
+  asic.dma.ch[0].enabled = true;
+  asic.dma.ch[0].source_address = 0x3FFF;
+
+  // Should not crash and should read instruction 0x1234 across bank boundary
+  asic_dma_cycle();
+}
+
 }  // namespace

--- a/test/fileutils.cpp
+++ b/test/fileutils.cpp
@@ -27,3 +27,11 @@ TEST(FileUtils, ListdirectoryNonMatchingExtension) {
 
   ASSERT_EQ(0, result.size());
 }
+
+TEST(FileUtils, ListdirectoryEmptyStringDoesNotCrash) {
+  // Before the fix, directory[directory.size() - 1] was UB when empty.
+  std::string directory = "";
+  std::vector<std::string> result = listDirectory(directory);
+  // Should not crash — empty directory either returns empty or fails gracefully
+  EXPECT_GE(result.size(), 0u);
+}

--- a/test/gif_recorder.cpp
+++ b/test/gif_recorder.cpp
@@ -1,0 +1,21 @@
+#include "gif_recorder.h"
+
+#include <gtest/gtest.h>
+
+TEST(GifRecorderTest, DestructorWithoutRecordingDoesNotCrash) {
+  // A GifRecorder that was never started should destroy cleanly.
+  GifRecorder gif;
+  EXPECT_FALSE(gif.is_recording());
+  // Destructor called here — should not crash.
+}
+
+TEST(GifRecorderTest, AbortWithoutRecordingDoesNotCrash) {
+  GifRecorder gif;
+  gif.abort();  // no-op when not recording
+  EXPECT_FALSE(gif.is_recording());
+}
+
+TEST(GifRecorderTest, FrameCountStartsAtZero) {
+  GifRecorder gif;
+  EXPECT_EQ(gif.frame_count(), 0);
+}

--- a/test/memory_access.cpp
+++ b/test/memory_access.cpp
@@ -1,0 +1,129 @@
+#include "z80.h"
+
+#include <gtest/gtest.h>
+
+#include "asic.h"
+#include "koncepcja.h"
+#include "layered_memory.h"
+#include "memory_bus.h"
+
+extern byte* membank_read[4];
+extern byte* membank_write[4];
+extern t_MemBankConfig membank_config;
+extern t_GateArray GateArray;
+extern byte* pbMF2ROM;
+extern dword dwMF2Flags;
+extern MemoryBus g_memory_bus;
+
+namespace {
+
+class MemoryAccessTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    // Set up a flat 64KB RAM layout: all 4 banks point to different
+    // 16KB slices of a contiguous 64KB buffer.
+    for (int i = 0; i < 4; i++) {
+      membank_read[i] = &ram_[i * 16384];
+      membank_write[i] = &ram_[i * 16384];
+    }
+    // Initialize membank_config for ASIC DMA tests
+    for (int cfg = 0; cfg < 8; cfg++) {
+      for (int bank = 0; bank < 4; bank++) {
+        membank_config[cfg][bank] = &ram_[bank * 16384];
+      }
+    }
+    // Reset MF2 state
+    dwMF2Flags = 0;
+    pbMF2ROM = mf2_rom_;
+    std::memset(mf2_rom_, 0, sizeof(mf2_rom_));
+    // Reset ASIC state
+    GateArray.registerPageOn = false;
+    asic.locked = false;
+    std::memset(ram_, 0, sizeof(ram_));
+  }
+
+  byte ram_[65536]{};
+  byte mf2_rom_[16384]{};  // MF2 ROM (0x0000-0x1FFF) + RAM (0x2000-0x3FFF)
+};
+
+TEST_F(MemoryAccessTest, CpuWriteGoesToBus) {
+  z80_cpu_write_mem(0x1234, 0xAB);
+  EXPECT_EQ(ram_[0x1234], 0xAB);
+}
+
+TEST_F(MemoryAccessTest, CpuWriteToMf2RangeWithoutMf2ActiveGoesToBus) {
+  dwMF2Flags = 0;  // MF2 not active
+  z80_cpu_write_mem(0x2000, 0x42);
+  EXPECT_EQ(ram_[0x2000], 0x42);
+  EXPECT_EQ(mf2_rom_[0x2000], 0);  // MF2 SRAM untouched
+}
+
+TEST_F(MemoryAccessTest, CpuWriteToMf2RangeWithMf2ActiveGoesToMf2Sram) {
+  dwMF2Flags = 0x01;  // MF2_ACTIVE
+  z80_cpu_write_mem(0x2000, 0x42);
+  EXPECT_EQ(mf2_rom_[0x2000], 0x42);
+  EXPECT_EQ(ram_[0x2000], 0);  // CPC RAM untouched
+}
+
+TEST_F(MemoryAccessTest, CpuWriteToMf2RangeBoundary) {
+  dwMF2Flags = 0x01;
+  // 0x1FFF is below MF2 range — should go to bus
+  z80_cpu_write_mem(0x1FFF, 0x11);
+  EXPECT_EQ(ram_[0x1FFF], 0x11);
+  // 0x2000 is start of MF2 range
+  z80_cpu_write_mem(0x2000, 0x22);
+  EXPECT_EQ(mf2_rom_[0x2000], 0x22);
+  // 0x3FFF is end of MF2 range
+  z80_cpu_write_mem(0x3FFF, 0x33);
+  EXPECT_EQ(mf2_rom_[0x3FFF], 0x33);
+  // 0x4000 is above MF2 range — should go to bus
+  z80_cpu_write_mem(0x4000, 0x44);
+  EXPECT_EQ(ram_[0x4000], 0x44);
+}
+
+TEST_F(MemoryAccessTest, CpuWriteVsDirectWriteMf2Behavior) {
+  dwMF2Flags = 0x01;
+  // z80_write_mem (direct) should bypass MF2 and write to bus
+  z80_write_mem(0x2000, 0xAA);
+  EXPECT_EQ(ram_[0x2000], 0xAA);
+  // z80_cpu_write_mem should redirect to MF2 SRAM
+  z80_cpu_write_mem(0x2500, 0xBB);
+  EXPECT_EQ(mf2_rom_[0x2500], 0xBB);
+  EXPECT_EQ(ram_[0x2500], 0);  // bus untouched
+}
+
+TEST_F(MemoryAccessTest, CpuReadReturnsBusValue) {
+  ram_[0x4000] = 0x77;
+  EXPECT_EQ(z80_cpu_read_mem(0x4000), 0x77);
+}
+
+TEST_F(MemoryAccessTest, CpuReadVsDirectReadIdentical) {
+  ram_[0x5000] = 0x99;
+  EXPECT_EQ(z80_cpu_read_mem(0x5000), z80_read_mem(0x5000));
+}
+
+TEST_F(MemoryAccessTest, LayeredMemoryCpuViewWriteMf2) {
+  dwMF2Flags = 0x01;
+  LayeredMemory mem;
+  mem.write_cpu(0x3000, 0xEE);
+  EXPECT_EQ(mf2_rom_[0x3000], 0xEE);
+  EXPECT_EQ(ram_[0x3000], 0);
+}
+
+TEST_F(MemoryAccessTest, LayeredMemoryDirectWriteBypassesMf2) {
+  dwMF2Flags = 0x01;
+  LayeredMemory mem;
+  mem.write_direct(0x3000, 0xEE);
+  EXPECT_EQ(ram_[0x3000], 0xEE);
+  EXPECT_EQ(mf2_rom_[0x3000], 0);
+}
+
+TEST_F(MemoryAccessTest, LayeredMemoryRawWriteBypassesEverything) {
+  dwMF2Flags = 0x01;
+  LayeredMemory mem;
+  mem.write_raw(0x3000, 0xFF);
+  EXPECT_EQ(ram_[0x3000], 0xFF);
+  EXPECT_EQ(mf2_rom_[0x3000], 0);
+}
+
+}  // namespace

--- a/test/memory_access.cpp
+++ b/test/memory_access.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <cstring>
+
 #include "asic.h"
 #include "koncepcja.h"
 #include "layered_memory.h"

--- a/test/memory_access.cpp
+++ b/test/memory_access.cpp
@@ -1,11 +1,10 @@
-#include "z80.h"
-
 #include <gtest/gtest.h>
 
 #include "asic.h"
 #include "koncepcja.h"
 #include "layered_memory.h"
 #include "memory_bus.h"
+#include "z80.h"
 
 extern byte* membank_read[4];
 extern byte* membank_write[4];


### PR DESCRIPTION
## Summary

- `z80_cpu_write_mem()` now applies MF2 RAM redirect + ASIC register page + IPC events — same layering as `write_mem()` but without watchpoints. Previously it was identical to `z80_write_mem()` (raw bus only), making the "CPU view" name misleading.
- `z80_cpu_read_mem()` was already correct (SmartWatch on upper ROM) — no change needed.
- `LayeredMemory` facade docs updated to reflect actual semantics.
- Roadmap updated: Phases 1-7 complete.

## Tests

10 new `MemoryAccessTest` cases:
- CPU view write with/without MF2 active
- MF2 range boundary behavior (0x1FFF, 0x2000, 0x3FFF, 0x4000)
- CPU vs direct vs raw write semantics
- LayeredMemory facade correctness (cpu/direct/raw paths)

## Testing

- Build: ✅ macOS
- Tests: 1128 ran, 1126 passed, 2 skipped (RamExpansion, pre-existing)