### PR TITLE
ui: show PAUSED instead of FPS counter when emulator is paused

### DIFF
--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -1253,13 +1253,16 @@ static void imgui_render_topbar() {
     // because popups from the fixed topbar close immediately in docked
     // mode due to focus interactions with the dockspace.
     {
-      // Right-align before FPS counter
-      float fps_w = 0.0f;
-      if (!imgui_state.topbar_fps.empty())
-        fps_w = ImGui::CalcTextSize(imgui_state.topbar_fps.c_str()).x + 16.0f;
+      // Right-align before rightmost element (PAUSED or FPS counter)
+      float right_w = 0.0f;
+      if (is_paused) {
+        right_w = ImGui::CalcTextSize("PAUSED").x + 16.0f;
+      } else if (!imgui_state.topbar_fps.empty()) {
+        right_w = ImGui::CalcTextSize(imgui_state.topbar_fps.c_str()).x + 16.0f;
+      }
       float btn_w = ImGui::CalcTextSize("Layout").x +
                     ImGui::GetStyle().FramePadding.x * 2.0f;
-      ImGui::SameLine(ImGui::GetWindowWidth() - fps_w - btn_w - 12.0f);
+      ImGui::SameLine(ImGui::GetWindowWidth() - right_w - btn_w - 12.0f);
 
       if (ImGui::Button("Layout")) {
         imgui_state.show_layout_dropdown = !imgui_state.show_layout_dropdown;

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -1269,7 +1269,14 @@ static void imgui_render_topbar() {
       s_layout_btn_pos.y = ImGui::GetItemRectMax().y + 2.0f;
     }
 
-    if (!imgui_state.topbar_fps.empty()) {
+    if (is_paused) {
+      float pause_width = ImGui::CalcTextSize("PAUSED").x;
+      ImGui::SameLine(ImGui::GetWindowWidth() - pause_width - 8);
+      ImGui::AlignTextToFramePadding();
+      ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.8f, 0.2f, 1.0f));
+      ImGui::TextUnformatted("PAUSED");
+      ImGui::PopStyleColor();
+    } else if (!imgui_state.topbar_fps.empty()) {
       float fps_width = ImGui::CalcTextSize(imgui_state.topbar_fps.c_str()).x;
       ImGui::SameLine(ImGui::GetWindowWidth() - fps_width - 8);
       ImGui::AlignTextToFramePadding();


### PR DESCRIPTION
## Summary

When the emulator is paused, the topbar right side now shows **PAUSED** in amber text instead of the stale FPS counter. Resumes showing FPS when unpaused.

## Testing

- Build: ✅ macOS
- Tests: 1133 ran, 1131 passed

Closes beads-7to.