### PR TITLE
fix(ui): close all devtools windows when toggling off, remove window forcing from layout presets

### DIFF
--- a/src/devtools_ui.cpp
+++ b/src/devtools_ui.cpp
@@ -125,6 +125,26 @@ bool DevToolsUI::any_window_open() const {
          show_recording_controls_ || show_assembler_;
 }
 
+void DevToolsUI::close_all_windows() {
+  show_registers_ = false;
+  show_disassembly_ = false;
+  show_memory_hex_ = false;
+  show_stack_ = false;
+  show_breakpoints_ = false;
+  show_symbols_ = false;
+  show_session_recording_ = false;
+  show_gfx_finder_ = false;
+  show_silicon_disc_ = false;
+  show_asic_ = false;
+  show_disc_tools_ = false;
+  show_data_areas_ = false;
+  show_disasm_export_ = false;
+  show_video_state_ = false;
+  show_audio_state_ = false;
+  show_recording_controls_ = false;
+  show_assembler_ = false;
+}
+
 const char* const* DevToolsUI::all_window_keys(int* count) {
   static const char* keys[] = {
       "registers",     "disassembly", "memory_hex",        "stack",

--- a/src/devtools_ui.h
+++ b/src/devtools_ui.h
@@ -20,6 +20,7 @@ class DevToolsUI {
   ~DevToolsUI();
   void render();
   void toggle_window(const std::string& name);
+  void close_all_windows();
 
   // Per-window render timing (microseconds, updated each frame)
   static constexpr int NUM_WINDOWS = 17;

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -1065,16 +1065,6 @@ static void render_layout_dropdown() {
         workspace_apply_preset(WorkspacePreset::Hardware);
         imgui_state.show_layout_dropdown = false;
       }
-    } else {
-      if (ImGui::MenuItem("Debug")) {
-        imgui_state.show_layout_dropdown = false;
-      }
-      if (ImGui::MenuItem("Memory")) {
-        imgui_state.show_layout_dropdown = false;
-      }
-      if (ImGui::MenuItem("Hardware")) {
-        imgui_state.show_layout_dropdown = false;
-      }
     }
 
     // Custom saved layouts

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -371,8 +371,10 @@ void imgui_init_ui() {
           cpc_pause();
       });
   g_command_palette.register_command(
-      "DevTools", "Open developer tools", "Shift+F2",
-      []() { imgui_state.show_devtools = !imgui_state.show_devtools; });
+      "DevTools", "Open developer tools", "Shift+F2", []() {
+        imgui_state.show_devtools = !imgui_state.show_devtools;
+        if (!imgui_state.show_devtools) g_devtools_ui.close_all_windows();
+      });
   g_command_palette.register_command(
       "Registers", "Show CPU registers", "",
       []() { g_devtools_ui.toggle_window("registers"); });
@@ -897,6 +899,7 @@ static void imgui_render_menubar() {
     }
     if (ImGui::MenuItem("DevTools", "Shift+F2")) {
       imgui_state.show_devtools = !imgui_state.show_devtools;
+      if (!imgui_state.show_devtools) g_devtools_ui.close_all_windows();
     }
     if (ImGui::MenuItem("Virtual Keyboard", "Shift+F1")) {
       koncpc_menu_action(KONCPC_VKBD);
@@ -909,7 +912,10 @@ static void imgui_render_menubar() {
 
   // ── Window ──
   if (ImGui::BeginMenu("Window")) {
-    ImGui::MenuItem("DevTools Toolbar", "Shift+F2", &imgui_state.show_devtools);
+    if (ImGui::MenuItem("DevTools Toolbar", "Shift+F2",
+                        &imgui_state.show_devtools)) {
+      if (!imgui_state.show_devtools) g_devtools_ui.close_all_windows();
+    }
     ImGui::MenuItem("Virtual Keyboard", "Shift+F1",
                     &imgui_state.show_vkeyboard);
     ImGui::MenuItem("Serial Terminal", nullptr,
@@ -1061,23 +1067,12 @@ static void render_layout_dropdown() {
       }
     } else {
       if (ImGui::MenuItem("Debug")) {
-        g_devtools_ui.toggle_window("registers");
-        g_devtools_ui.toggle_window("disassembly");
-        g_devtools_ui.toggle_window("stack");
-        g_devtools_ui.toggle_window("breakpoints");
         imgui_state.show_layout_dropdown = false;
       }
       if (ImGui::MenuItem("Memory")) {
-        g_devtools_ui.toggle_window("memory_hex");
-        g_devtools_ui.toggle_window("symbols");
-        g_devtools_ui.toggle_window("data_areas");
         imgui_state.show_layout_dropdown = false;
       }
       if (ImGui::MenuItem("Hardware")) {
-        g_devtools_ui.toggle_window("video_state");
-        g_devtools_ui.toggle_window("audio_state");
-        g_devtools_ui.toggle_window("asic");
-        g_devtools_ui.toggle_window("silicon_disc");
         imgui_state.show_layout_dropdown = false;
       }
     }


### PR DESCRIPTION
## Summary

Two UI bug fixes:

**beads-mdf — Devtools toggle hides bar but not windows:** Toggling devtools off via menu, command palette, or Shift+F2 now closes all devtools windows (registers, disassembly, memory, etc.) along with the toolbar. Added `DevToolsUI::close_all_windows()` method.

**beads-569 — Layout button opens preset windows:** Classic-mode layout presets (Debug/Memory/Hardware) no longer force specific devtools windows open. Window visibility is now independent of layout mode.

## Testing

- Build: ✅ macOS
- Tests: 1133 ran, 1131 passed

Closes beads-mdf, beads-569.