### PR TITLE
UX reshape: action single-source-of-truth + Core UI / DevTools cleanup

### DIFF
--- a/src/argparse.cpp
+++ b/src/argparse.cpp
@@ -5,68 +5,90 @@
 #else
 #include <getopt.h>
 #endif
+#include <fstream>
 #include <iomanip>
 #include <iostream>
-#include <fstream>
 #include <map>
 #include <string>
+
 #include "SDL3/SDL.h"
-#include "koncepcja.h"
 #include "keyboard.h"
-#include "stringutils.h"
+#include "koncepcja.h"
 #include "log.h"
+#include "stringutils.h"
 #include "video.h"
 
-const struct option long_options[] =
-{
-   {"autocmd",       required_argument, nullptr, 'a'},
-   {"cfg_file",      required_argument, nullptr, 'c'},
-   {"exit-after",    required_argument, nullptr, 'E'},
-   {"exit-on-break", no_argument, nullptr, 'B'},
-   {"headless",      no_argument, nullptr, 'H'},
-   {"inject",        required_argument, nullptr, 'i'},
-   {"list-plugins",  no_argument, nullptr, 'L'},
-   {"offset",        required_argument, nullptr, 'o'},
-   {"override",      required_argument, nullptr, 'O'},
-   {"sym_file",      required_argument, nullptr, 's'},
-   {"version",       no_argument, nullptr, 'V'},
-   {"help",          no_argument, nullptr, 'h'},
-   {"verbose",       no_argument, nullptr, 'v'},
-   {"debug",         no_argument, nullptr, 'D'},
-   {nullptr, 0, nullptr, 0},
+const struct option long_options[] = {
+    {"autocmd", required_argument, nullptr, 'a'},
+    {"cfg_file", required_argument, nullptr, 'c'},
+    {"exit-after", required_argument, nullptr, 'E'},
+    {"exit-on-break", no_argument, nullptr, 'B'},
+    {"headless", no_argument, nullptr, 'H'},
+    {"inject", required_argument, nullptr, 'i'},
+    {"list-plugins", no_argument, nullptr, 'L'},
+    {"offset", required_argument, nullptr, 'o'},
+    {"override", required_argument, nullptr, 'O'},
+    {"sym_file", required_argument, nullptr, 's'},
+    {"version", no_argument, nullptr, 'V'},
+    {"help", no_argument, nullptr, 'h'},
+    {"verbose", no_argument, nullptr, 'v'},
+    {"debug", no_argument, nullptr, 'D'},
+    {"fps", no_argument, nullptr, 'F'},
+    {nullptr, 0, nullptr, 0},
 };
 
-void usage(std::ostream &os, char *progPath, int errcode)
-{
-   std::string progname, dirname;
+void usage(std::ostream& os, char* progPath, int errcode) {
+  std::string progname, dirname;
 
-   stringutils::splitPath(progPath, dirname, progname);
+  stringutils::splitPath(progPath, dirname, progname);
 
-   os << "Usage: " << progname << " [options] <slotfile(s)>\n";
-   os << "\nSupported options are:\n";
-   os << "   -a/--autocmd=<command>: execute command after CPC boots (repeatable).\n";
-   os << "      Supports WinAPE ~KEY~ syntax: ~ENTER~, ~CLR~, ~PAUSE 50~, ~+SHIFT~, etc.\n";
-   os << "      Also accepts KONCPC_EXIT, KONCPC_WAITBREAK, KONCPC_RESET and other\n";
-   os << "      emulator commands (see docs/ipc-protocol.md for the full list).\n";
-   os << "   -B/--exit-on-break:     exit with code 1 when a breakpoint is hit (instead of pausing).\n";
-   os << "   -c/--cfg_file=<file>:   use <file> as the emulator configuration file instead of the default.\n";
-   os << "   -E/--exit-after=<spec>: exit after N frames (e.g. 100f), seconds (5s), or milliseconds (3000ms).\n";
-   os << "   -H/--headless:          run without display or audio (IPC and emulation only).\n";
-   os << "   -h/--help:              shows this help\n";
-   os << "   -i/--inject=<file>:     inject a binary in memory after the CPC startup finishes\n";
-   os << "   -L/--list-plugins:      list all video plugins (index: name) and exit\n";
-   os << "   -o/--offset=<address>:  offset at which to inject the binary provided with -i (default: 0x6000)\n";
-   os << "   -O/--override:          override an option from the config. Can be repeated. (example: -O system.model=3)\n";
-   os << "   -s/--sym_file=<file>:   use <file> as a source of symbols and entry points for disassembling in developers' tools.\n";
-   os << "   -V/--version:           outputs version and exit\n";
-   os << "   -v/--verbose:           be talkative\n";
-   os << "   -D/--debug:             show frame timing and audio diagnostics in DevTools bar\n";
-   os << "\nslotfiles is an optional list of files giving the content of the various CPC ports.\n";
-   os << "Ports files are identified by their extension. Supported formats are .dsk (disk), .cdt or .voc (tape), .cpr (cartridge), .sna (snapshot), or .zip (archive containing one or more of the supported ports files).\n";
-   os << "\nExample: " << progname << " sorcery.dsk\n";
-   os << "\nPress F1 when the emulator is running to show the in-application option menu.\n";
-   os << "\nSee https://github.com/ikari/konCePCja or check the man page (man koncepcja) for more extensive information.\n";
-   exit(errcode);
+  os << "Usage: " << progname << " [options] <slotfile(s)>\n";
+  os << "\nSupported options are:\n";
+  os << "   -a/--autocmd=<command>: execute command after CPC boots "
+        "(repeatable).\n";
+  os << "      Supports WinAPE ~KEY~ syntax: ~ENTER~, ~CLR~, ~PAUSE 50~, "
+        "~+SHIFT~, etc.\n";
+  os << "      Also accepts KONCPC_EXIT, KONCPC_WAITBREAK, KONCPC_RESET and "
+        "other\n";
+  os << "      emulator commands (see docs/ipc-protocol.md for the full "
+        "list).\n";
+  os << "   -B/--exit-on-break:     exit with code 1 when a breakpoint is hit "
+        "(instead of pausing).\n";
+  os << "   -c/--cfg_file=<file>:   use <file> as the emulator configuration "
+        "file instead of the default.\n";
+  os << "   -E/--exit-after=<spec>: exit after N frames (e.g. 100f), seconds "
+        "(5s), or milliseconds (3000ms).\n";
+  os << "   -H/--headless:          run without display or audio (IPC and "
+        "emulation only).\n";
+  os << "   -h/--help:              shows this help\n";
+  os << "   -i/--inject=<file>:     inject a binary in memory after the CPC "
+        "startup finishes\n";
+  os << "   -L/--list-plugins:      list all video plugins (index: name) and "
+        "exit\n";
+  os << "   -o/--offset=<address>:  offset at which to inject the binary "
+        "provided with -i (default: 0x6000)\n";
+  os << "   -O/--override:          override an option from the config. Can be "
+        "repeated. (example: -O system.model=3)\n";
+  os << "   -s/--sym_file=<file>:   use <file> as a source of symbols and "
+        "entry points for disassembling in developers' tools.\n";
+  os << "   -V/--version:           outputs version and exit\n";
+  os << "   -v/--verbose:           be talkative\n";
+  os << "   -D/--debug:             show frame timing and audio diagnostics in "
+        "DevTools bar\n";
+  os << "   --fps:                  log once-per-second FPS to stdout (e.g. "
+        "'[fps] 50 FPS 100% speed')\n";
+  os << "\nslotfiles is an optional list of files giving the content of the "
+        "various CPC ports.\n";
+  os << "Ports files are identified by their extension. Supported formats are "
+        ".dsk (disk), .cdt or .voc (tape), .cpr (cartridge), .sna (snapshot), "
+        "or .zip (archive containing one or more of the supported ports "
+        "files).\n";
+  os << "\nExample: " << progname << " sorcery.dsk\n";
+  os << "\nPress F1 when the emulator is running to show the in-application "
+        "option menu.\n";
+  os << "\nSee https://github.com/ikari/konCePCja or check the man page (man "
+        "koncepcja) for more extensive information.\n";
+  exit(errcode);
 }
 
 std::string koncpc_keystroke(KONCPC_KEYS key) {
@@ -77,34 +99,31 @@ std::string cpc_keystroke(CPC_KEYS key) {
   return std::string("\a") + char(key);
 }
 
-std::string replaceKoncpcKeys(std::string command)
-{
+std::string replaceKoncpcKeys(std::string command) {
   static std::map<std::string, std::string> keyNames = {
-    { "KONCPC_EXIT", koncpc_keystroke(KONCPC_EXIT) },
-    { "KONCPC_FPS", koncpc_keystroke(KONCPC_FPS) },
-    { "KONCPC_FULLSCRN", koncpc_keystroke(KONCPC_FULLSCRN) },
-    { "KONCPC_GUI", koncpc_keystroke(KONCPC_GUI) },
-    { "KONCPC_VKBD", koncpc_keystroke(KONCPC_VKBD) },
-    { "KONCPC_JOY", koncpc_keystroke(KONCPC_JOY) },
-    { "KONCPC_PHAZER", koncpc_keystroke(KONCPC_PHAZER) },
-    { "KONCPC_MF2STOP", koncpc_keystroke(KONCPC_MF2STOP) },
-    { "KONCPC_RESET", koncpc_keystroke(KONCPC_RESET) },
-    { "KONCPC_SCRNSHOT", koncpc_keystroke(KONCPC_SCRNSHOT) },
-    { "KONCPC_SPEED", koncpc_keystroke(KONCPC_SPEED) },
-    { "KONCPC_TAPEPLAY", koncpc_keystroke(KONCPC_TAPEPLAY) },
-    { "KONCPC_DEBUG", koncpc_keystroke(KONCPC_DEBUG) },
-    { "KONCPC_WAITBREAK", koncpc_keystroke(KONCPC_WAITBREAK) },
-    { "KONCPC_DELAY", koncpc_keystroke(KONCPC_DELAY) },
-    { "KONCPC_PASTE", koncpc_keystroke(KONCPC_PASTE) },
-    { "KONCPC_DEVTOOLS", koncpc_keystroke(KONCPC_DEVTOOLS) },
-    { "CPC_F1", cpc_keystroke(CPC_F1) },
-    { "CPC_F2", cpc_keystroke(CPC_F2) },
+      {"KONCPC_EXIT", koncpc_keystroke(KONCPC_EXIT)},
+      {"KONCPC_FPS", koncpc_keystroke(KONCPC_FPS)},
+      {"KONCPC_FULLSCRN", koncpc_keystroke(KONCPC_FULLSCRN)},
+      {"KONCPC_GUI", koncpc_keystroke(KONCPC_GUI)},
+      {"KONCPC_VKBD", koncpc_keystroke(KONCPC_VKBD)},
+      {"KONCPC_JOY", koncpc_keystroke(KONCPC_JOY)},
+      {"KONCPC_PHAZER", koncpc_keystroke(KONCPC_PHAZER)},
+      {"KONCPC_MF2STOP", koncpc_keystroke(KONCPC_MF2STOP)},
+      {"KONCPC_RESET", koncpc_keystroke(KONCPC_RESET)},
+      {"KONCPC_SCRNSHOT", koncpc_keystroke(KONCPC_SCRNSHOT)},
+      {"KONCPC_SPEED", koncpc_keystroke(KONCPC_SPEED)},
+      {"KONCPC_TAPEPLAY", koncpc_keystroke(KONCPC_TAPEPLAY)},
+      {"KONCPC_DEBUG", koncpc_keystroke(KONCPC_DEBUG)},
+      {"KONCPC_WAITBREAK", koncpc_keystroke(KONCPC_WAITBREAK)},
+      {"KONCPC_DELAY", koncpc_keystroke(KONCPC_DELAY)},
+      {"KONCPC_PASTE", koncpc_keystroke(KONCPC_PASTE)},
+      {"KONCPC_DEVTOOLS", koncpc_keystroke(KONCPC_DEVTOOLS)},
+      {"CPC_F1", cpc_keystroke(CPC_F1)},
+      {"CPC_F2", cpc_keystroke(CPC_F2)},
   };
-  for (const auto& elt : keyNames)
-  {
+  for (const auto& elt : keyNames) {
     size_t pos;
-    while ((pos = command.find(elt.first)) != std::string::npos)
-    {
+    while ((pos = command.find(elt.first)) != std::string::npos) {
       command.replace(pos, elt.first.size(), elt.second);
       LOG_VERBOSE("Recognized keyword: " << elt.first);
     }
@@ -112,145 +131,148 @@ std::string replaceKoncpcKeys(std::string command)
   return command;
 }
 
-void parseArguments(int argc, char **argv, std::vector<std::string>& slot_list, CapriceArgs& args)
-{
-   int option_index = 0;
-   int c;
+void parseArguments(int argc, char** argv, std::vector<std::string>& slot_list,
+                    CapriceArgs& args) {
+  int option_index = 0;
+  int c;
 
-   optind = 0; // To please test framework, when this function is called multiple times !
-   while(true) {
-      c = getopt_long (argc, argv, "a:Bc:E:Hhi:Lo:O:s:vV",
-                       long_options, &option_index);
-      // Logs before processing of the -v will not be visible.
-      LOG_DEBUG("Next option: " << c << "(" << static_cast<char>(c) << ")");
+  optind = 0;  // To please test framework, when this function is called
+               // multiple times !
+  while (true) {
+    c = getopt_long(argc, argv, "a:Bc:E:Hhi:Lo:O:s:vV", long_options,
+                    &option_index);
+    // Logs before processing of the -v will not be visible.
+    LOG_DEBUG("Next option: " << c << "(" << static_cast<char>(c) << ")");
 
-      /* Detect the end of the options. */
-      if (c == -1)
-         break;
+    /* Detect the end of the options. */
+    if (c == -1) break;
 
-      switch (c)
-      {
-         case 'a':
-            LOG_VERBOSE("Append to autocmd: " << optarg);
-            args.autocmd += replaceKoncpcKeys(optarg);
-            args.autocmd += "\n";
-            break;
+    switch (c) {
+      case 'a':
+        LOG_VERBOSE("Append to autocmd: " << optarg);
+        args.autocmd += replaceKoncpcKeys(optarg);
+        args.autocmd += "\n";
+        break;
 
-         case 'c':
-            args.cfgFilePath = optarg;
-            break;
+      case 'c':
+        args.cfgFilePath = optarg;
+        break;
 
-         case 'B':
-            args.exitOnBreak = true;
-            break;
+      case 'B':
+        args.exitOnBreak = true;
+        break;
 
-         case 'E':
-            args.exitAfter = optarg;
-            break;
+      case 'E':
+        args.exitAfter = optarg;
+        break;
 
-         case 'H':
-            args.headless = true;
-            break;
+      case 'H':
+        args.headless = true;
+        break;
 
-         case 'h':
-            usage(std::cout, argv[0], 0);
-            break;
+      case 'h':
+        usage(std::cout, argv[0], 0);
+        break;
 
-         case 'i':
-            args.binFile = optarg;
-            break;
+      case 'i':
+        args.binFile = optarg;
+        break;
 
-         case 'o':
-            args.binOffset = std::stol(optarg, nullptr, 0);
-            break;
+      case 'o':
+        args.binOffset = std::stol(optarg, nullptr, 0);
+        break;
 
-         case 'O':
-            {
-              std::string opt(optarg);
-              bool invalid = false;
-              auto key_value_separator = opt.find('=');
-              if (key_value_separator == std::string::npos) invalid = true;
-              std::string key = opt.substr(0, key_value_separator);
-              std::string value = opt.substr(key_value_separator+1);
-              auto section_item_separator = key.find('.');
-              if (section_item_separator == std::string::npos) invalid = true;
-              std::string section = key.substr(0, section_item_separator);
-              std::string item = key.substr(section_item_separator+1);
-              if (invalid || section.empty() || item.empty()) {
-                LOG_ERROR("Couldn't parse override: '" << opt << "'");
-              } else {
-                args.cfgOverrides[section][item] = value;
-                LOG_INFO("Override configuration: " << section << "." << item << " = " << value);
-              }
-              break;
-            }
+      case 'O': {
+        std::string opt(optarg);
+        bool invalid = false;
+        auto key_value_separator = opt.find('=');
+        if (key_value_separator == std::string::npos) invalid = true;
+        std::string key = opt.substr(0, key_value_separator);
+        std::string value = opt.substr(key_value_separator + 1);
+        auto section_item_separator = key.find('.');
+        if (section_item_separator == std::string::npos) invalid = true;
+        std::string section = key.substr(0, section_item_separator);
+        std::string item = key.substr(section_item_separator + 1);
+        if (invalid || section.empty() || item.empty()) {
+          LOG_ERROR("Couldn't parse override: '" << opt << "'");
+        } else {
+          args.cfgOverrides[section][item] = value;
+          LOG_INFO("Override configuration: " << section << "." << item << " = "
+                                              << value);
+        }
+        break;
+      }
 
-         case 'L':
-            // List all video plugins (index: name) and exit.  Helps users
-            // recover from scr_style index shifts after plugin-list edits
-            // (e.g. Phase 7b removed the legacy GL CRT plugins, shifting
-            // every plugin after them down by three slots).
-            {
-               size_t last = video_plugin_list.empty() ? 0 : video_plugin_list.size() - 1;
-               int width = 1;
-               for (size_t v = last; v >= 10; v /= 10) ++width;
-               for (size_t i = 0; i < video_plugin_list.size(); ++i) {
-                  std::cout << std::setw(width) << i << ": "
-                            << video_plugin_list[i].name << '\n';
-               }
-            }
-            exit(0);
-            break;
+      case 'L':
+        // List all video plugins (index: name) and exit.  Helps users
+        // recover from scr_style index shifts after plugin-list edits
+        // (e.g. Phase 7b removed the legacy GL CRT plugins, shifting
+        // every plugin after them down by three slots).
+        {
+          size_t last =
+              video_plugin_list.empty() ? 0 : video_plugin_list.size() - 1;
+          int width = 1;
+          for (size_t v = last; v >= 10; v /= 10) ++width;
+          for (size_t i = 0; i < video_plugin_list.size(); ++i) {
+            std::cout << std::setw(width) << i << ": "
+                      << video_plugin_list[i].name << '\n';
+          }
+        }
+        exit(0);
+        break;
 
-         case 's':
-            args.symFilePath = optarg;
-            break;
+      case 's':
+        args.symFilePath = optarg;
+        break;
 
-         case 'D':
-            args.debug = true;
-            break;
-         case 'v':
-            log_verbose = true;
-            break;
+      case 'D':
+        args.debug = true;
+        break;
+      case 'F':
+        args.fps = true;
+        break;
+      case 'v':
+        log_verbose = true;
+        break;
 
-         case 'V':
-            // Version
-            std::cout << "konCePCja " << VERSION_STRING;
+      case 'V':
+        // Version
+        std::cout << "konCePCja " << VERSION_STRING;
 #ifdef HASH
-            std::cout << (std::string(HASH).empty()?"":"-"+std::string(HASH));
+        std::cout << (std::string(HASH).empty() ? "" : "-" + std::string(HASH));
 #endif
-            std::cout << "\n";
+        std::cout << "\n";
 
-            // APP_PATH
-            std::cout << "APP_PATH: ";
-            #ifdef APP_PATH
-            std::cout << APP_PATH;
-            #else
-            std::cout << "Not provided";
-            #endif
-            std::cout << std::endl;
+        // APP_PATH
+        std::cout << "APP_PATH: ";
+#ifdef APP_PATH
+        std::cout << APP_PATH;
+#else
+        std::cout << "Not provided";
+#endif
+        std::cout << std::endl;
 
-            // Flags
-            std::cout << "Compiled with:"
+        // Flags
+        std::cout << "Compiled with:"
 #ifdef DEBUG
-                      << " DEBUG"
+                  << " DEBUG"
 #endif
-                      << "\n";
+                  << "\n";
 
-            // Video plugins
-            std::cout << "Number of video plugins available: "
-                      << video_plugin_list.size() << std::endl;
-            exit(0);
-            break;
+        // Video plugins
+        std::cout << "Number of video plugins available: "
+                  << video_plugin_list.size() << std::endl;
+        exit(0);
+        break;
 
-         case '?':
-         default:
-            usage(std::cerr, argv[0], 1);
-            break;
-       }
-   }
+      case '?':
+      default:
+        usage(std::cerr, argv[0], 1);
+        break;
+    }
+  }
 
-   /* All remaining command line arguments will go to the slot content list */
-   slot_list.assign(argv+optind, argv+argc);
-   LOG_DEBUG("slot_list: " << stringutils::join(slot_list, ","))
+  /* All remaining command line arguments will go to the slot content list */
+  slot_list.assign(argv + optind, argv + argc);
+  LOG_DEBUG("slot_list: " << stringutils::join(slot_list, ","))
 }

--- a/src/argparse.h
+++ b/src/argparse.h
@@ -5,23 +5,24 @@
 #include <string>
 #include <vector>
 
-class CapriceArgs
-{
-   public:
-      CapriceArgs() = default;
-      std::string autocmd;
-      std::string cfgFilePath;
-      std::string binFile;
-      size_t binOffset;
-      std::map<std::string, std::map<std::string, std::string>> cfgOverrides;
-      std::string symFilePath;
-      bool headless = false;
-      std::string exitAfter;       // e.g. "100f", "5s", "3000ms"
-      bool exitOnBreak = false;
-      bool debug = false;
+class CapriceArgs {
+ public:
+  CapriceArgs() = default;
+  std::string autocmd;
+  std::string cfgFilePath;
+  std::string binFile;
+  size_t binOffset;
+  std::map<std::string, std::map<std::string, std::string>> cfgOverrides;
+  std::string symFilePath;
+  bool headless = false;
+  std::string exitAfter;  // e.g. "100f", "5s", "3000ms"
+  bool exitOnBreak = false;
+  bool debug = false;
+  bool fps = false;  // --fps: log once-per-second FPS to stdout
 };
 
 std::string replaceKoncpcKeys(std::string command);
-void parseArguments(int argc, char** argv, std::vector<std::string>& slot_list, CapriceArgs& args);
+void parseArguments(int argc, char** argv, std::vector<std::string>& slot_list,
+                    CapriceArgs& args);
 
 #endif

--- a/src/devtools_ui.cpp
+++ b/src/devtools_ui.cpp
@@ -200,6 +200,45 @@ void DevToolsUI::navigate_memory(word addr) {
 }
 
 // -----------------------------------------------
+// Default window layout (beads-a34 / beads-pv7)
+// -----------------------------------------------
+
+// The "core debugging window set": auto-opened on first F12 and docked by the
+// Debug workspace preset.  Defined once here so the two paths can't drift
+// (beads-igq).
+const char* const* DevToolsUI::core_debug_window_keys() {
+  static const char* const keys[] = {"registers",   "disassembly", "stack",
+                                     "breakpoints", "memory_hex",  nullptr};
+  return keys;
+}
+
+void DevToolsUI::open_core_debug_windows() {
+  for (const char* const* k = core_debug_window_keys(); *k; ++k) {
+    if (!is_window_open(*k)) toggle_window(*k);
+  }
+}
+
+void DevToolsUI::apply_default_window_layout(int stagger, float w, float h) {
+  // Stagger windows in a few columns so they don't cascade onto one origin
+  // and don't march off the bottom-right edge with 17 windows.  Coordinates
+  // are relative to the viewport work area (below the menubar/topbar), not
+  // magic screen pixels, so the default layout follows the UI chrome.
+  const ImGuiViewport* vp = ImGui::GetMainViewport();
+  const int kCols = 4;
+  const float kStepX = 60.0f;
+  const float kStepY = 36.0f;
+  int col = stagger % kCols;
+  int row = stagger / kCols;
+  ImVec2 pos(vp->WorkPos.x + 20.0f + col * 230.0f + row * kStepX,
+             vp->WorkPos.y + 20.0f + row * kStepY + col * kStepY);
+
+  ImGuiCond cond =
+      reset_positions_pending_ ? ImGuiCond_Always : ImGuiCond_FirstUseEver;
+  ImGui::SetNextWindowSize(ImVec2(w, h), ImGuiCond_FirstUseEver);
+  ImGui::SetNextWindowPos(pos, cond);
+}
+
+// -----------------------------------------------
 // Main render dispatch
 // -----------------------------------------------
 
@@ -247,6 +286,11 @@ void DevToolsUI::render() {
   time_window(15, "Recording", show_recording_controls_,
               [&] { render_recording_controls(); });
   time_window(16, "Assembler", show_assembler_, [&] { render_assembler(); });
+
+  // The reset-positions request lasts exactly one frame: every window's
+  // apply_default_window_layout() has now run with ImGuiCond_Always
+  // (beads-pv7).
+  reset_positions_pending_ = false;
 }
 
 // -----------------------------------------------
@@ -254,8 +298,7 @@ void DevToolsUI::render() {
 // -----------------------------------------------
 
 void DevToolsUI::render_registers() {
-  ImGui::SetNextWindowSize(ImVec2(340, 420), ImGuiCond_FirstUseEver);
-  ImGui::SetNextWindowPos(ImVec2(620, 60), ImGuiCond_FirstUseEver);
+  apply_default_window_layout(0, 340, 420);
 
   bool open = true;
   if (!ImGui::Begin("Registers", &open)) {
@@ -426,8 +469,7 @@ void DevToolsUI::disasm_cache_record_pc() {
 }
 
 void DevToolsUI::render_disassembly() {
-  ImGui::SetNextWindowSize(ImVec2(440, 500), ImGuiCond_FirstUseEver);
-  ImGui::SetNextWindowPos(ImVec2(10, 60), ImGuiCond_FirstUseEver);
+  apply_default_window_layout(1, 440, 500);
 
   bool open = true;
   if (!ImGui::Begin("Disassembly", &open, ImGuiWindowFlags_MenuBar)) {
@@ -789,8 +831,7 @@ void DevToolsUI::render_disassembly() {
 // -----------------------------------------------
 
 void DevToolsUI::render_memory_hex() {
-  ImGui::SetNextWindowSize(ImVec2(520, 400), ImGuiCond_FirstUseEver);
-  ImGui::SetNextWindowPos(ImVec2(460, 60), ImGuiCond_FirstUseEver);
+  apply_default_window_layout(2, 520, 400);
 
   bool open = true;
   if (!ImGui::Begin("Memory Hex", &open, ImGuiWindowFlags_MenuBar)) {
@@ -1204,8 +1245,7 @@ void DevToolsUI::render_memory_hex() {
 // -----------------------------------------------
 
 void DevToolsUI::render_stack() {
-  ImGui::SetNextWindowSize(ImVec2(260, 400), ImGuiCond_FirstUseEver);
-  ImGui::SetNextWindowPos(ImVec2(460, 440), ImGuiCond_FirstUseEver);
+  apply_default_window_layout(3, 260, 400);
 
   bool open = true;
   if (!ImGui::Begin("Stack", &open)) {
@@ -1286,8 +1326,7 @@ void DevToolsUI::render_stack() {
 // -----------------------------------------------
 
 void DevToolsUI::render_breakpoints() {
-  ImGui::SetNextWindowSize(ImVec2(500, 300), ImGuiCond_FirstUseEver);
-  ImGui::SetNextWindowPos(ImVec2(10, 540), ImGuiCond_FirstUseEver);
+  apply_default_window_layout(4, 500, 300);
 
   bool open = true;
   if (!ImGui::Begin("Breakpoints & Watchpoints & IO###BPWindow", &open)) {
@@ -1590,8 +1629,7 @@ void DevToolsUI::render_symbols() {
   snprintf(title, sizeof(title), "Symbols (%d)###SymbolTable",
            static_cast<int>(syms.size()));
 
-  ImGui::SetNextWindowSize(ImVec2(340, 400), ImGuiCond_FirstUseEver);
-  ImGui::SetNextWindowPos(ImVec2(520, 540), ImGuiCond_FirstUseEver);
+  apply_default_window_layout(5, 340, 400);
 
   bool open = true;
   if (!ImGui::Begin(title, &open)) {
@@ -1692,7 +1730,7 @@ void DevToolsUI::render_symbols() {
 // -----------------------------------------------
 
 void DevToolsUI::render_silicon_disc() {
-  ImGui::SetNextWindowSize(ImVec2(380, 280), ImGuiCond_FirstUseEver);
+  apply_default_window_layout(6, 380, 280);
 
   bool open = true;
   if (!ImGui::Begin("Silicon Disc", &open)) {
@@ -1761,7 +1799,7 @@ void DevToolsUI::render_silicon_disc() {
 // -----------------------------------------------
 
 void DevToolsUI::render_asic() {
-  ImGui::SetNextWindowSize(ImVec2(520, 500), ImGuiCond_FirstUseEver);
+  apply_default_window_layout(7, 520, 500);
 
   bool open = true;
   if (!ImGui::Begin("ASIC Registers", &open)) {
@@ -1866,7 +1904,7 @@ void DevToolsUI::render_asic() {
 // -----------------------------------------------
 
 void DevToolsUI::render_disc_tools() {
-  ImGui::SetNextWindowSize(ImVec2(520, 500), ImGuiCond_FirstUseEver);
+  apply_default_window_layout(8, 520, 500);
 
   bool open = true;
   if (!ImGui::Begin("Disc Tools", &open)) {
@@ -2138,7 +2176,7 @@ void DevToolsUI::render_disc_tools() {
 // -----------------------------------------------
 
 void DevToolsUI::render_data_areas() {
-  ImGui::SetNextWindowSize(ImVec2(560, 350), ImGuiCond_FirstUseEver);
+  apply_default_window_layout(9, 560, 350);
 
   bool open = true;
   if (!ImGui::Begin("Data Areas", &open)) {
@@ -2287,7 +2325,7 @@ void DevToolsUI::render_disasm_export() {
     dex_prefill_pending_ = false;
   }
 
-  ImGui::SetNextWindowSize(ImVec2(420, 450), ImGuiCond_FirstUseEver);
+  apply_default_window_layout(10, 420, 450);
 
   bool open = true;
   if (!ImGui::Begin("Disassembly Export", &open)) {
@@ -2536,7 +2574,7 @@ void DevToolsUI::render_disasm_export() {
 // -----------------------------------------------
 
 void DevToolsUI::render_session_recording() {
-  ImGui::SetNextWindowSize(ImVec2(400, 200), ImGuiCond_FirstUseEver);
+  apply_default_window_layout(11, 400, 200);
 
   bool open = true;
   if (!ImGui::Begin("Session Recording", &open)) {
@@ -2638,7 +2676,7 @@ void DevToolsUI::render_session_recording() {
 // -----------------------------------------------
 
 void DevToolsUI::render_gfx_finder() {
-  ImGui::SetNextWindowSize(ImVec2(500, 500), ImGuiCond_FirstUseEver);
+  apply_default_window_layout(12, 500, 500);
 
   bool open = true;
   if (!ImGui::Begin("Graphics Finder", &open)) {
@@ -2801,7 +2839,7 @@ void DevToolsUI::render_gfx_finder() {
 // -----------------------------------------------
 
 void DevToolsUI::render_video_state() {
-  ImGui::SetNextWindowSize(ImVec2(340, 420), ImGuiCond_FirstUseEver);
+  apply_default_window_layout(13, 340, 420);
 
   bool open = true;
   if (!ImGui::Begin("Video State", &open)) {
@@ -2924,7 +2962,7 @@ static void draw_scope_strip(const char* label, ImU32 color,
 }
 
 void DevToolsUI::render_audio_state() {
-  ImGui::SetNextWindowSize(ImVec2(420, 600), ImGuiCond_FirstUseEver);
+  apply_default_window_layout(14, 420, 600);
 
   bool open = true;
   if (!ImGui::Begin("Audio State", &open)) {
@@ -3042,7 +3080,7 @@ static std::string format_size(uint64_t bytes) {
 }
 
 void DevToolsUI::render_recording_controls() {
-  ImGui::SetNextWindowSize(ImVec2(420, 400), ImGuiCond_FirstUseEver);
+  apply_default_window_layout(15, 420, 400);
 
   bool open = true;
   if (!ImGui::Begin("Recording Controls", &open)) {
@@ -3394,7 +3432,7 @@ static std::string asm_build_source_with_org(const char* source,
 }
 
 void DevToolsUI::render_assembler() {
-  ImGui::SetNextWindowSize(ImVec2(700, 550), ImGuiCond_FirstUseEver);
+  apply_default_window_layout(16, 700, 550);
   bool open = true;
   if (!ImGui::Begin("Assembler##devtools", &open)) {
     ImGui::End();

--- a/src/devtools_ui.cpp
+++ b/src/devtools_ui.cpp
@@ -1,5 +1,6 @@
 #include "devtools_ui.h"
 
+#include <cfloat>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -56,6 +57,17 @@ static bool has_path_traversal(const char* path) {
 
 // Consistent link color for all navigable addresses
 static constexpr ImVec4 kLinkColor(0.4f, 0.8f, 1.0f, 1.0f);
+
+// Small colored chip showing whether the emulated machine is running or
+// paused. Rendered at the top of detachable debug windows so a user with a
+// floating window can tell at a glance if the machine is live. (beads-rj4)
+static void render_run_state_chip() {
+  if (!g_emu_paused.load()) {
+    ImGui::TextColored(ImVec4(0.3f, 0.85f, 0.3f, 1.0f), "RUNNING");
+  } else {
+    ImGui::TextColored(ImVec4(0.95f, 0.75f, 0.2f, 1.0f), "PAUSED");
+  }
+}
 
 DevToolsUI g_devtools_ui;
 
@@ -252,17 +264,41 @@ void DevToolsUI::render_registers() {
     return;
   }
 
+  render_run_state_chip();  // beads-rj4
+  ImGui::Separator();
+
   bool locked = !CPC.paused;
   ImGuiInputTextFlags hex_flags = ImGuiInputTextFlags_CharsHexadecimal |
                                   (locked ? ImGuiInputTextFlags_ReadOnly : 0);
 
+  // beads-pra: make the disabled state visible while running.
+  if (locked) {
+    ImGui::TextDisabled("(pause to edit registers)");
+  }
+  ImGui::BeginDisabled(locked);
+
+  // beads-9a9: right-click context menu on a 16-bit register field to jump to
+  // its current value in the Memory or Disassembly view.
+  auto RegContextMenu = [&](const char* id, word value) {
+    if (ImGui::BeginPopupContextItem(id)) {
+      if (ImGui::MenuItem("View in Memory"))
+        navigate_to(value, NavTarget::MEMORY);
+      if (ImGui::MenuItem("View in Disassembly"))
+        navigate_to(value, NavTarget::DISASM);
+      ImGui::EndPopup();
+    }
+  };
+
   auto RegField16 = [&](const char* label, reg_pair& rp) {
     unsigned short val = rp.w.l;
-    ImGui::SetNextItemWidth(60);
+    ImGui::SetNextItemWidth(-FLT_MIN);
     if (ImGui::InputScalar(label, ImGuiDataType_U16, &val, nullptr, nullptr,
                            "%04X", hex_flags)) {
       if (!locked) rp.w.l = val;
     }
+    // Context menu uses the live register value (rp.w.l), so it stays correct
+    // even while the field is disabled and editing is blocked.
+    RegContextMenu(label, rp.w.l);
   };
 
   auto RegField8 = [&](const char* label, byte& val) {
@@ -274,38 +310,47 @@ void DevToolsUI::render_registers() {
     }
   };
 
-  // Main registers in two columns
-  ImGui::Columns(2, "regs_main", false);
-  RegField16("AF", z80.AF);
-  ImGui::NextColumn();
-  RegField16("AF'", z80.AFx);
-  ImGui::NextColumn();
-  RegField16("BC", z80.BC);
-  ImGui::NextColumn();
-  RegField16("BC'", z80.BCx);
-  ImGui::NextColumn();
-  RegField16("DE", z80.DE);
-  ImGui::NextColumn();
-  RegField16("DE'", z80.DEx);
-  ImGui::NextColumn();
-  RegField16("HL", z80.HL);
-  ImGui::NextColumn();
-  RegField16("HL'", z80.HLx);
-  ImGui::NextColumn();
-  RegField16("IX", z80.IX);
-  ImGui::NextColumn();
-  RegField16("IY", z80.IY);
-  ImGui::NextColumn();
-  RegField16("SP", z80.SP);
-  ImGui::NextColumn();
-  RegField16("PC", z80.PC);
-  ImGui::NextColumn();
-  ImGui::Columns(1);
+  // beads-083: main / shadow register pairs in a stretch-prop table so the
+  // grid reflows when the window is widened.
+  if (ImGui::BeginTable("regs", 2, ImGuiTableFlags_SizingStretchProp)) {
+    auto reg_row = [&](const char* main_label, reg_pair& main_rp,
+                       const char* shadow_label, reg_pair& shadow_rp) {
+      ImGui::TableNextRow();
+      ImGui::TableSetColumnIndex(0);
+      RegField16(main_label, main_rp);
+      ImGui::TableSetColumnIndex(1);
+      RegField16(shadow_label, shadow_rp);
+    };
+    // Main vs shadow (AF/AF' ...) pairs.
+    reg_row("AF", z80.AF, "AF'", z80.AFx);
+    reg_row("BC", z80.BC, "BC'", z80.BCx);
+    reg_row("DE", z80.DE, "DE'", z80.DEx);
+    reg_row("HL", z80.HL, "HL'", z80.HLx);
+    ImGui::EndTable();
+  }
+
+  ImGui::Spacing();
+  // Index / stack / program registers (no shadow counterparts).
+  if (ImGui::BeginTable("regs_idx", 2, ImGuiTableFlags_SizingStretchProp)) {
+    ImGui::TableNextRow();
+    ImGui::TableSetColumnIndex(0);
+    RegField16("IX", z80.IX);
+    ImGui::TableSetColumnIndex(1);
+    RegField16("IY", z80.IY);
+    ImGui::TableNextRow();
+    ImGui::TableSetColumnIndex(0);
+    RegField16("SP", z80.SP);
+    ImGui::TableSetColumnIndex(1);
+    RegField16("PC", z80.PC);
+    ImGui::EndTable();
+  }
 
   ImGui::Spacing();
   RegField8("I", z80.I);
   ImGui::SameLine();
   RegField8("R", z80.R);
+
+  ImGui::EndDisabled();  // beads-pra: re-enable read-only info below
 
   // Interrupt state
   ImGui::Spacing();
@@ -322,6 +367,7 @@ void DevToolsUI::render_registers() {
   byte f = z80.AF.b.l;
   bool s = f & Sflag, zf = f & Zflag, h = f & Hflag, pv = f & Pflag,
        n = f & Nflag, cf = f & Cflag;
+  ImGui::BeginDisabled(locked);  // beads-pra: flags editable only when paused
   ImGui::Checkbox("S", &s);
   ImGui::SameLine();
   ImGui::Checkbox("Z", &zf);
@@ -333,6 +379,7 @@ void DevToolsUI::render_registers() {
   ImGui::Checkbox("N", &n);
   ImGui::SameLine();
   ImGui::Checkbox("C", &cf);
+  ImGui::EndDisabled();
   if (!locked) {
     byte new_f = 0;
     if (s) new_f |= Sflag;
@@ -411,6 +458,11 @@ void DevToolsUI::render_disassembly() {
           "Click lines to toggle breakpoints. Right-click for more options.");
     ImGui::EndMenuBar();
   }
+
+  render_run_state_chip();  // beads-rj4
+  ImGui::SameLine();
+  ImGui::TextDisabled("|");
+  ImGui::SameLine();
 
   // Determine the center address
   word center_pc = z80.PC.w.l;
@@ -528,9 +580,17 @@ void DevToolsUI::render_disassembly() {
     ImGui::PopStyleColor();
   }
 
+  // beads-5nd: track which line is selected (selection is separate from
+  // breakpoint toggling). Plain left-click on a line selects it; the leading
+  // gutter toggles a breakpoint. Persisted across frames via static.
+  static int disasm_selected_addr = -1;
+
   if (ImGui::BeginChild("##disasm_scroll", ImVec2(0, 0),
                         ImGuiChildFlags_Borders)) {
     int scroll_to_idx = -1;
+
+    // Fixed-width gutter so rows never reflow whether or not a BP marker shows.
+    const float gutter_w = ImGui::GetFrameHeight();
 
     for (int i = 0; i < static_cast<int>(lines.size()); i++) {
       const auto& entry = lines[i];
@@ -562,12 +622,41 @@ void DevToolsUI::render_disassembly() {
         ImGui::PopStyleColor();
       }
 
-      // Build display text
+      // Build display text (the breakpoint marker lives in the gutter column,
+      // so the main label is reflow-free regardless of BP state).
       static constexpr const char* kBreakpointMarker =
           "\xe2\x97\x8f";  // Unicode ●
       char label[256];
-      snprintf(label, sizeof(label), "%s %04X  %s",
-               is_bp ? kBreakpointMarker : " ", entry.addr, entry.text.c_str());
+      snprintf(label, sizeof(label), "%04X  %s", entry.addr,
+               entry.text.c_str());
+
+      // --- Breakpoint gutter (beads-5nd) ---
+      // A narrow leading Selectable. Clicking it toggles a breakpoint without
+      // selecting the line. Only meaningful for code (not data areas).
+      ImGui::PushID(i);
+      ImVec2 gutter_pos = ImGui::GetCursorScreenPos();
+      bool gutter_clicked =
+          ImGui::Selectable("##bpgutter", false, ImGuiSelectableFlags_None,
+                            ImVec2(gutter_w, ImGui::GetTextLineHeight()));
+      if (!entry.is_data_area && ImGui::IsItemHovered()) {
+        ImGui::SetTooltip(is_bp ? "Click: remove breakpoint"
+                                : "Click: add breakpoint");
+        ImGui::SetMouseCursor(ImGuiMouseCursor_Hand);
+      }
+      if (gutter_clicked && !entry.is_data_area) {
+        if (is_bp)
+          z80_del_breakpoint(entry.addr);
+        else
+          z80_add_breakpoint(entry.addr);
+      }
+      if (is_bp) {
+        ImVec2 tsz = ImGui::CalcTextSize(kBreakpointMarker);
+        ImGui::GetWindowDrawList()->AddText(
+            ImVec2(gutter_pos.x + (gutter_w - tsz.x) * 0.5f, gutter_pos.y),
+            IM_COL32(255, 77, 77, 255), kBreakpointMarker);
+      }
+      ImGui::PopID();
+      ImGui::SameLine(0.0f, 4.0f);
 
       // Color: green for PC, red for breakpoint, amber for data area, purple
       // for ROM
@@ -589,9 +678,14 @@ void DevToolsUI::render_disassembly() {
         style_colors_pushed = 1;
       }
 
-      if (ImGui::Selectable(label, is_pc || entry.is_data_area)) {
-        if (!entry.is_data_area) {
-          // Left click: toggle breakpoint (not meaningful for data areas)
+      bool is_selected = (static_cast<int>(entry.addr) == disasm_selected_addr);
+      if (ImGui::Selectable(label,
+                            is_pc || entry.is_data_area || is_selected)) {
+        // beads-5nd: plain left-click only selects the line. Ctrl-click is a
+        // convenience shortcut that also toggles the breakpoint (mirrors the
+        // gutter).
+        disasm_selected_addr = static_cast<int>(entry.addr);
+        if (!entry.is_data_area && ImGui::GetIO().KeyCtrl) {
           if (is_bp)
             z80_del_breakpoint(entry.addr);
           else
@@ -603,7 +697,8 @@ void DevToolsUI::render_disassembly() {
           ImGui::SetTooltip("Data area | Right-click: edit/remove");
         else
           ImGui::SetTooltip(
-              "Click: toggle breakpoint | Right-click: more options");
+              "Click: select | Gutter / Ctrl+click: toggle breakpoint | "
+              "Right-click: more options");
         ImGui::SetMouseCursor(ImGuiMouseCursor_Hand);
       }
 
@@ -1119,8 +1214,10 @@ void DevToolsUI::render_stack() {
     return;
   }
 
+  render_run_state_chip();  // beads-rj4
+  ImGui::SameLine();
   word sp = z80.SP.w.l;
-  ImGui::Text("SP = %04X", sp);
+  ImGui::Text("| SP = %04X", sp);
   ImGui::Separator();
 
   if (ImGui::BeginChild("##stack_entries", ImVec2(0, 0),
@@ -1205,6 +1302,34 @@ void DevToolsUI::render_breakpoints() {
   if (ImGui::Button("Clear All WPs")) z80_clear_watchpoints();
   ImGui::SameLine();
   if (ImGui::Button("Clear All IOBPs")) z80_clear_io_breakpoints();
+
+  // beads-w38: quick inline "add breakpoint by address" row. Accepts a hex
+  // address or a known symbol name (resolved via the symbol file).
+  {
+    static char quick_bp_addr[16] = "";
+    auto add_quick_bp = [&]() {
+      if (quick_bp_addr[0] == '\0') return;
+      unsigned long addr;
+      word sym_addr = 0;
+      if (parse_hex(quick_bp_addr, &addr, 0xFFFF)) {
+        z80_add_breakpoint(static_cast<word>(addr));
+        quick_bp_addr[0] = '\0';
+      } else if (g_symfile.lookupName(quick_bp_addr, sym_addr) == 0) {
+        // Symbol name resolved to an address.
+        z80_add_breakpoint(sym_addr);
+        quick_bp_addr[0] = '\0';
+      } else {
+        imgui_toast_error("Bad breakpoint address/symbol");
+      }
+    };
+    ImGui::SetNextItemWidth(90);
+    if (ImGui::InputText("##quickbp", quick_bp_addr, sizeof(quick_bp_addr),
+                         ImGuiInputTextFlags_EnterReturnsTrue))
+      add_quick_bp();
+    if (ImGui::IsItemHovered()) ImGui::SetTooltip("Hex address or symbol name");
+    ImGui::SameLine();
+    if (ImGui::Button("Add BP##quick")) add_quick_bp();
+  }
 
   const auto& bps = z80_list_breakpoints_ref();
   const auto& wps = z80_list_watchpoints_ref();

--- a/src/devtools_ui.h
+++ b/src/devtools_ui.h
@@ -43,6 +43,21 @@ class DevToolsUI {
   // Returns the array of all window key strings (NUM_WINDOWS entries).
   static const char* const* all_window_keys(int* count);
 
+  // Returns the "core debugging window set" — the windows that DevTools
+  // auto-opens on first F12 and that the Debug workspace preset docks.
+  // Single source of truth so the auto-open path and the preset can't drift
+  // (beads-igq).  Array is null-terminated and static.
+  static const char* const* core_debug_window_keys();
+
+  // Open the core debugging window set (registers/disassembly/stack/...).
+  // Safe to call repeatedly — only opens windows that are currently closed.
+  void open_core_debug_windows();
+
+  // Re-apply the default staggered window positions on the next frame, so a
+  // user whose floating windows have drifted off-screen can recover them
+  // (beads-pv7).  The next render() uses ImGuiCond_Always for one frame.
+  void reset_window_positions() { reset_positions_pending_ = true; }
+
   // Request cache invalidation — safe to call from any thread.
   // Actual clearing happens on the next render() call (main thread).
   void disasm_cache_invalidate() { disasm_cache_pending_clear_.store(true); }
@@ -63,6 +78,17 @@ class DevToolsUI {
 
  private:
   WindowTiming window_timings_[NUM_WINDOWS] = {};
+
+  // Default-position layout (beads-a34 / beads-pv7).  Each window declares its
+  // default size and a stagger index; positions are computed relative to the
+  // main viewport's work area so they respect the menubar/topbar and never
+  // cascade onto a single origin.  When reset_positions_pending_ is set the
+  // next render forces ImGuiCond_Always for one frame to recover drifted
+  // windows.
+  bool reset_positions_pending_ = false;
+  // Apply size + staggered default position for the window currently being
+  // begun.  `stagger` is the window's slot index (see render() dispatch order).
+  void apply_default_window_layout(int stagger, float w, float h);
 
   bool show_registers_ = false;
   bool show_disassembly_ = false;

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -3263,6 +3263,27 @@ static void imgui_render_devtools() {
     ImGui::SameLine();
     if (ImGui::Button("ASM")) g_devtools_ui.toggle_window("assembler");
 
+    // Layout controls reachable from where the windows are (beads-p0e/pv7):
+    // a rescue for windows that drifted off-screen in Classic mode, plus the
+    // docking presets that were previously only in the topbar Layout dropdown.
+    ImGui::SameLine();
+    if (ImGui::Button("Layout")) ImGui::OpenPopup("##dt_layout");
+    if (ImGui::BeginPopup("##dt_layout")) {
+      if (ImGui::MenuItem("Reset Window Positions")) {
+        g_devtools_ui.reset_window_positions();
+      }
+      ImGui::Separator();
+      if (ImGui::MenuItem("Apply Debug Layout")) {
+        CPC.workspace_layout = t_CPC::WorkspaceLayoutMode::Docked;
+        workspace_apply_preset(WorkspacePreset::Debug);
+      }
+      if (ImGui::MenuItem("Apply IDE Layout")) {
+        CPC.workspace_layout = t_CPC::WorkspaceLayoutMode::Docked;
+        workspace_apply_preset(WorkspacePreset::IDE);
+      }
+      ImGui::EndPopup();
+    }
+
     ImGui::SameLine();
     if (ImGui::Button("Export")) ImGui::OpenPopup("##dt_export");
     if (ImGui::BeginPopup("##dt_export")) {

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -692,6 +692,46 @@ void imgui_close_menu() {
 // Main Menu Bar
 // ─────────────────────────────────────────────────
 
+// Live toggle state for a toggle-kind action (drives menu checkmarks across the
+// ImGui menus and the native macOS menu).  This is the GUI-side half of the
+// action registry — menu_actions.cpp holds the labels, the binding map holds
+// the shortcuts, and this reads the live emulator/UI state.
+bool koncpc_action_is_active(KONCPC_KEYS action) {
+  switch (action) {
+    case KONCPC_FPS:
+      return CPC.scr_fps != 0;
+    case KONCPC_SPEED:
+      return CPC.limit_speed != 0;
+    case KONCPC_JOY:
+      return CPC.joystick_emulation != JoystickEmulation::None;
+    case KONCPC_PHAZER:
+      return static_cast<bool>(CPC.phazer_emulation);
+    case KONCPC_DEVTOOLS:
+      return imgui_state.show_devtools;
+    case KONCPC_DEBUG:
+      return log_verbose;
+    default:
+      return false;
+  }
+}
+
+// Render one ImGui menu item for an action, pulling its canonical label,
+// derived shortcut hint and live checkmark from the single source of truth, and
+// routing the click through the one koncpc_menu_action() sink.  Every
+// emulator-command menu item should go through here so labels/shortcuts can
+// never drift.
+static bool RenderMenuItem(KONCPC_KEYS action, bool enabled = true) {
+  const MenuAction* meta = koncpc_find_action(action);
+  if (meta == nullptr) return false;
+  std::string sc = koncpc_action_shortcut(action);
+  const char* shortcut = sc.empty() ? nullptr : sc.c_str();
+  bool clicked =
+      ImGui::MenuItem(meta->title, shortcut,
+                      meta->toggle && koncpc_action_is_active(action), enabled);
+  if (clicked) koncpc_menu_action(action);
+  return clicked;
+}
+
 static void imgui_render_menubar() {
   if (!ImGui::BeginMainMenuBar()) return;
 

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -456,6 +456,11 @@ void imgui_render_ui() {
   // Dockspace host must be rendered before other windows so they can dock into
   // it
   workspace_render_dockspace();
+  // TODO(beads-34s): add a small dark host gutter / 1px inner bezel around the
+  // emulated CPC screen so it doesn't touch the topbar/status bar. The screen
+  // texture/quad is drawn in workspace_render_cpc_screen()
+  // (workspace_layout.cpp), which is outside this file's edit scope — handle it
+  // there.
   workspace_render_cpc_screen();
   imgui_render_menubar();
   imgui_render_topbar();
@@ -846,6 +851,11 @@ static void imgui_render_menubar() {
               static_cast<intptr_t>(FileDialogAction::SaveSnapshot)),
           mainSDLWindow, filters, 1, CPC.current_snap_path.c_str());
     }
+    // beads-5aa: group the default-slot quick snapshot actions so their labels
+    // (which read like speed adjectives in isolation) are clearly about the
+    // default slot. Canonical labels live in menu_actions.cpp (not edited).
+    ImGui::Separator();
+    ImGui::TextDisabled("Default slot");
     RenderMenuItem(KONCPC_SNAPSHOT);
     RenderMenuItem(KONCPC_LD_SNAP);
     ImGui::Separator();
@@ -951,12 +961,22 @@ static void imgui_render_menubar() {
   // ── Tools ──
   if (ImGui::BeginMenu("Tools")) {
     RenderMenuItem(KONCPC_DEVTOOLS);
+    // beads-qnf: surface the Cmd+K command palette (previously only mentioned
+    // in the About box) as a discoverable menu entry.
+    if (ImGui::MenuItem("Command Palette...", "Cmd+K")) {
+      g_command_palette.open();
+    }
     if (ImGui::MenuItem("Virtual Keyboard", "Shift+F1")) {
       koncpc_menu_action(KONCPC_VKBD);
     }
     if (ImGui::MenuItem("MF2 Stop", "F6")) {
       koncpc_menu_action(KONCPC_MF2STOP);
     }
+    // beads-41p: developer/diagnostics group — Verbose Logging moved here from
+    // the Options menu (where it sat among player toggles).
+    ImGui::Separator();
+    ImGui::TextDisabled("Diagnostics");
+    RenderMenuItem(KONCPC_DEBUG);
     ImGui::EndMenu();
   }
 
@@ -1022,7 +1042,8 @@ static void imgui_render_menubar() {
     RenderMenuItem(KONCPC_PHAZER);
     RenderMenuItem(KONCPC_SPEED);
     RenderMenuItem(KONCPC_FPS);
-    RenderMenuItem(KONCPC_DEBUG);
+    // beads-41p: KONCPC_DEBUG (Verbose Logging) relocated to Tools >
+    // Diagnostics.
     ImGui::EndMenu();
   }
 
@@ -1255,6 +1276,17 @@ static void imgui_render_topbar() {
     // the Z80 thread). When paused, the button resumes; when running, it opens
     // the F1 menu and pauses, exactly as before.
     const bool is_paused = g_emu_paused.load(std::memory_order_relaxed);
+    // beads-uvo: reserve the gold/amber accent for the PAUSED state. While
+    // running, the Pause button gets a flat neutral fill so the gold only
+    // means "something is halted"; when paused, the Resume button keeps the
+    // theme's gold so the call-to-action stands out.
+    if (!is_paused) {
+      ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.20f, 0.20f, 0.23f, 1.0f));
+      ImGui::PushStyleColor(ImGuiCol_ButtonHovered,
+                            ImVec4(0.28f, 0.28f, 0.32f, 1.0f));
+      ImGui::PushStyleColor(ImGuiCol_ButtonActive,
+                            ImVec4(0.34f, 0.34f, 0.38f, 1.0f));
+    }
     if (ImGui::Button(is_paused ? "Resume (Esc)" : "Pause (F1)")) {
       if (is_paused) {
         cpc_resume();
@@ -1265,8 +1297,38 @@ static void imgui_render_topbar() {
         cpc_pause();
       }
     }
+    if (!is_paused) ImGui::PopStyleColor(3);
     // (Tape waveform moved to bottom status bar)
 
+    // beads-rwc: reformat the run-on FPS string ("50FPS 100%") produced by the
+    // emulator core into "50 FPS · 100%" (space + middle-dot separator) for
+    // legibility. Done here at the display site because the producer lives in
+    // another translation unit.
+    std::string fps_display;
+    if (!imgui_state.topbar_fps.empty()) {
+      const std::string& raw = imgui_state.topbar_fps;
+      size_t fpos = raw.find("FPS");
+      if (fpos != std::string::npos) {
+        // Left part = digits before "FPS"; right part = remainder after "FPS".
+        std::string left = raw.substr(0, fpos);
+        std::string right = raw.substr(fpos + 3);
+        // Trim surrounding spaces from both halves.
+        auto trim = [](std::string& s) {
+          size_t a = s.find_first_not_of(' ');
+          size_t b = s.find_last_not_of(' ');
+          s = (a == std::string::npos) ? std::string() : s.substr(a, b - a + 1);
+        };
+        trim(left);
+        trim(right);
+        fps_display = left + " FPS \xc2\xb7 " + right;  // U+00B7 middle dot
+      } else {
+        fps_display = raw;
+      }
+    }
+
+    // ── Right status cluster: Layout button + (PAUSED | FPS) ──
+    // beads-ptu: group the Layout button and the status readout so they read as
+    // one right-aligned status zone, with a faint leading divider.
     // ── Layout dropdown ──
     // Uses a state-flag + standalone window instead of ImGui popup,
     // because popups from the fixed topbar close immediately in docked
@@ -1276,33 +1338,59 @@ static void imgui_render_topbar() {
       float right_w = 0.0f;
       if (is_paused) {
         right_w = ImGui::CalcTextSize("PAUSED").x + 16.0f;
-      } else if (!imgui_state.topbar_fps.empty()) {
-        right_w = ImGui::CalcTextSize(imgui_state.topbar_fps.c_str()).x + 16.0f;
+      } else if (!fps_display.empty()) {
+        right_w = ImGui::CalcTextSize(fps_display.c_str()).x + 16.0f;
       }
       float btn_w = ImGui::CalcTextSize("Layout").x +
                     ImGui::GetStyle().FramePadding.x * 2.0f;
-      ImGui::SameLine(ImGui::GetWindowWidth() - right_w - btn_w - 12.0f);
+      // Reserve room for the leading divider + spacing (8px).
+      ImGui::SameLine(ImGui::GetWindowWidth() - right_w - btn_w - 12.0f - 8.0f);
 
+      // Leading vertical separator marking the start of the status zone.
+      {
+        ImVec2 sc = ImGui::GetCursorScreenPos();
+        float frameH = ImGui::GetFrameHeight();
+        ImGui::GetWindowDrawList()->AddLine(
+            ImVec2(sc.x, sc.y + 3.0f), ImVec2(sc.x, sc.y + frameH - 3.0f),
+            IM_COL32(0x50, 0x50, 0x50, 0xFF), 1.0f);
+        ImGui::Dummy(ImVec2(1.0f, frameH));
+        ImGui::SameLine(0, 8.0f);
+      }
+
+      ImGui::BeginGroup();
       if (ImGui::Button("Layout")) {
         imgui_state.show_layout_dropdown = !imgui_state.show_layout_dropdown;
       }
       // Remember button position for dropdown window placement
       s_layout_btn_pos = ImGui::GetItemRectMin();
       s_layout_btn_pos.y = ImGui::GetItemRectMax().y + 2.0f;
+
+      if (is_paused) {
+        float pause_width = ImGui::CalcTextSize("PAUSED").x;
+        ImGui::SameLine(ImGui::GetWindowWidth() - pause_width - 8);
+        ImGui::AlignTextToFramePadding();
+        ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.8f, 0.2f, 1.0f));
+        ImGui::TextUnformatted("PAUSED");
+        ImGui::PopStyleColor();
+      } else if (!fps_display.empty()) {
+        float fps_width = ImGui::CalcTextSize(fps_display.c_str()).x;
+        ImGui::SameLine(ImGui::GetWindowWidth() - fps_width - 8);
+        ImGui::AlignTextToFramePadding();
+        ImGui::TextUnformatted(fps_display.c_str());
+      }
+      ImGui::EndGroup();
     }
 
-    if (is_paused) {
-      float pause_width = ImGui::CalcTextSize("PAUSED").x;
-      ImGui::SameLine(ImGui::GetWindowWidth() - pause_width - 8);
-      ImGui::AlignTextToFramePadding();
-      ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.8f, 0.2f, 1.0f));
-      ImGui::TextUnformatted("PAUSED");
-      ImGui::PopStyleColor();
-    } else if (!imgui_state.topbar_fps.empty()) {
-      float fps_width = ImGui::CalcTextSize(imgui_state.topbar_fps.c_str()).x;
-      ImGui::SameLine(ImGui::GetWindowWidth() - fps_width - 8);
-      ImGui::AlignTextToFramePadding();
-      ImGui::TextUnformatted(imgui_state.topbar_fps.c_str());
+    // beads-sxd: subtle bottom separator so the native title bar, menu bar, and
+    // topbar don't merge into one undifferentiated dark band. Drawn 1px lighter
+    // than the topbar background at the bottom edge of the window.
+    {
+      ImVec2 wp = ImGui::GetWindowPos();
+      ImVec2 ws = ImGui::GetWindowSize();
+      float yb = wp.y + ws.y - 0.5f;
+      ImGui::GetWindowDrawList()->AddLine(
+          ImVec2(wp.x, yb), ImVec2(wp.x + ws.x, yb),
+          IM_COL32(0x2A, 0x2A, 0x2E, 0xFF), 1.0f);
     }
   }
   ImGui::End();
@@ -1842,6 +1930,19 @@ static void imgui_render_statusbar() {
               "Click to cycle waveform mode (RAW pulse / decoded BITS)");
         }
       }
+    }
+
+    // ── First-run empty-state hint ──
+    // beads-mng: when no media is loaded anywhere, show an unobtrusive,
+    // right-aligned dim hint so a fresh launch isn't a blank dead-end.
+    if (driveA.tracks == 0 && driveB.tracks == 0 && pbTapeImage.empty()) {
+      const char* hint = "Drop a .dsk/.cdt or press F1 to load";
+      float hint_w = ImGui::CalcTextSize(hint).x;
+      ImGui::SameLine(ImGui::GetWindowWidth() - hint_w - 10.0f);
+      ImGui::AlignTextToFramePadding();
+      ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.45f, 0.45f, 0.45f, 1.0f));
+      ImGui::TextUnformatted(hint);
+      ImGui::PopStyleColor();
     }
 
     // ── Eject Disk confirmation popup ──

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -351,8 +351,8 @@ void imgui_init_ui() {
   for (const auto& ma : koncpc_menu_actions()) {
     if (ma.title[0] == '\0') continue;  // skip empty entries
     std::string title = ma.title;
-    std::string shortcut = ma.shortcut ? ma.shortcut : "";
     KONCPC_KEYS action_key = ma.action;
+    std::string shortcut = koncpc_action_shortcut(action_key);
     g_command_palette.register_command(title, "", shortcut, [action_key]() {
       extern std::atomic<byte> keyboard_matrix[];
       applyKeypress(static_cast<CPCScancode>(action_key), keyboard_matrix,
@@ -369,11 +369,6 @@ void imgui_init_ui() {
           cpc_resume();
         else
           cpc_pause();
-      });
-  g_command_palette.register_command(
-      "DevTools", "Open developer tools", "Shift+F2", []() {
-        imgui_state.show_devtools = !imgui_state.show_devtools;
-        if (!imgui_state.show_devtools) g_devtools_ui.close_all_windows();
       });
   g_command_palette.register_command(
       "Registers", "Show CPU registers", "",
@@ -747,26 +742,15 @@ static void imgui_render_menubar() {
       imgui_state.show_options = true;
     }
     ImGui::Separator();
-    if (ImGui::MenuItem("Fullscreen", "F2")) {
-      koncpc_menu_action(KONCPC_FULLSCRN);
-    }
-    if (ImGui::MenuItem("Screenshot", "F3")) {
-      koncpc_menu_action(KONCPC_SCRNSHOT);
-    }
-    if (ImGui::MenuItem("Paste", "F11")) {
-      koncpc_menu_action(KONCPC_PASTE);
-    }
+    RenderMenuItem(KONCPC_FULLSCRN);
+    RenderMenuItem(KONCPC_SCRNSHOT);
+    RenderMenuItem(KONCPC_PASTE);
     ImGui::Separator();
-    if (ImGui::MenuItem("Reset", "F5")) {
-      emulator_reset();
-    }
+    RenderMenuItem(KONCPC_RESET);
     if (ImGui::MenuItem("About...")) {
       imgui_state.show_about = true;
     }
-    if (ImGui::MenuItem("Quit", "F10")) {
-      imgui_state.show_quit_confirm = true;
-      cpc_pause();
-    }
+    RenderMenuItem(KONCPC_EXIT);
     ImGui::EndMenu();
   }
 
@@ -823,12 +807,8 @@ static void imgui_render_menubar() {
               static_cast<intptr_t>(FileDialogAction::SaveSnapshot)),
           mainSDLWindow, filters, 1, CPC.current_snap_path.c_str());
     }
-    if (ImGui::MenuItem("Quick Save Snapshot", "Shift+F3")) {
-      koncpc_menu_action(KONCPC_SNAPSHOT);
-    }
-    if (ImGui::MenuItem("Quick Load Snapshot", "Shift+F4")) {
-      koncpc_menu_action(KONCPC_LD_SNAP);
-    }
+    RenderMenuItem(KONCPC_SNAPSHOT);
+    RenderMenuItem(KONCPC_LD_SNAP);
     ImGui::Separator();
     if (ImGui::MenuItem("Load Tape...")) {
       static const SDL_DialogFileFilter filters[] = {
@@ -839,9 +819,7 @@ static void imgui_render_menubar() {
               static_cast<intptr_t>(FileDialogAction::LoadTape)),
           mainSDLWindow, filters, 1, CPC.current_tape_path.c_str(), false);
     }
-    if (ImGui::MenuItem("Tape Play/Stop", "F4", false, !pbTapeImage.empty())) {
-      koncpc_menu_action(KONCPC_TAPEPLAY);
-    }
+    RenderMenuItem(KONCPC_TAPEPLAY, !pbTapeImage.empty());
     if (ImGui::MenuItem("Eject Tape", nullptr, false, !pbTapeImage.empty())) {
       tape_eject();
       CPC.tape.file.clear();
@@ -933,14 +911,7 @@ static void imgui_render_menubar() {
 
   // ── Tools ──
   if (ImGui::BeginMenu("Tools")) {
-    if (ImGui::MenuItem("Memory Tool")) {
-      imgui_state.show_devtools = true;
-      g_devtools_ui.toggle_window("memory_hex");
-    }
-    if (ImGui::MenuItem("DevTools", "Shift+F2")) {
-      imgui_state.show_devtools = !imgui_state.show_devtools;
-      if (!imgui_state.show_devtools) g_devtools_ui.close_all_windows();
-    }
+    RenderMenuItem(KONCPC_DEVTOOLS);
     if (ImGui::MenuItem("Virtual Keyboard", "Shift+F1")) {
       koncpc_menu_action(KONCPC_VKBD);
     }
@@ -952,10 +923,6 @@ static void imgui_render_menubar() {
 
   // ── Window ──
   if (ImGui::BeginMenu("Window")) {
-    if (ImGui::MenuItem("DevTools Toolbar", "Shift+F2",
-                        &imgui_state.show_devtools)) {
-      if (!imgui_state.show_devtools) g_devtools_ui.close_all_windows();
-    }
     ImGui::MenuItem("Virtual Keyboard", "Shift+F1",
                     &imgui_state.show_vkeyboard);
     ImGui::MenuItem("Serial Terminal", nullptr,
@@ -1012,23 +979,11 @@ static void imgui_render_menubar() {
 
   // ── Options ──
   if (ImGui::BeginMenu("Options")) {
-    if (ImGui::MenuItem("Joystick Emulation", "F7",
-                        CPC.joystick_emulation != JoystickEmulation::None)) {
-      koncpc_menu_action(KONCPC_JOY);
-    }
-    if (ImGui::MenuItem("Phazer Emulation", "Shift+F7",
-                        static_cast<bool>(CPC.phazer_emulation))) {
-      koncpc_menu_action(KONCPC_PHAZER);
-    }
-    if (ImGui::MenuItem("Speed Limit", "F9", CPC.limit_speed != 0)) {
-      koncpc_menu_action(KONCPC_SPEED);
-    }
-    if (ImGui::MenuItem("Show FPS", "F8", CPC.scr_fps != 0)) {
-      koncpc_menu_action(KONCPC_FPS);
-    }
-    if (ImGui::MenuItem("Verbose Logging", "F12", log_verbose)) {
-      koncpc_menu_action(KONCPC_DEBUG);
-    }
+    RenderMenuItem(KONCPC_JOY);
+    RenderMenuItem(KONCPC_PHAZER);
+    RenderMenuItem(KONCPC_SPEED);
+    RenderMenuItem(KONCPC_FPS);
+    RenderMenuItem(KONCPC_DEBUG);
     ImGui::EndMenu();
   }
 

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -551,13 +551,24 @@ void imgui_render_ui() {
   }
   if (ImGui::BeginPopupModal("Confirm Quit", nullptr,
                              ImGuiWindowFlags_AlwaysAutoResize)) {
-    ImGui::Text("Are you sure you want to quit?");
+    // P0: warn about unsaved disk changes here, since this GUI quit path passes
+    // askIfUnsaved=false to cleanExit() and so skips the native unsaved-disk
+    // guard that the OS window-close path enforces (beads-bgs).
+    if (driveAltered()) {
+      ImGui::TextColored(ImVec4(0.95f, 0.75f, 0.2f, 1.0f),
+                         "You have unsaved changes to a disk.");
+      ImGui::TextUnformatted("Quit anyway? Those changes will be lost.");
+    } else {
+      ImGui::TextUnformatted("Are you sure you want to quit?");
+    }
     ImGui::Spacing();
-    if (ImGui::Button("Yes", ImVec2(80, 0))) {
+    if (ImGui::Button("Quit", ImVec2(90, 0))) {
       cleanExit(0, false);
     }
     ImGui::SameLine();
-    if (ImGui::Button("No", ImVec2(80, 0))) {
+    bool cancel = ImGui::Button("Cancel", ImVec2(90, 0));
+    ImGui::SetItemDefaultFocus();  // focus the safe button by default
+    if (cancel || ImGui::IsKeyPressed(ImGuiKey_Escape)) {
       ImGui::CloseCurrentPopup();
       if (!imgui_state.show_menu && !imgui_state.show_options) {
         cpc_resume();
@@ -725,6 +736,34 @@ static bool RenderMenuItem(KONCPC_KEYS action, bool enabled = true) {
                       meta->toggle && koncpc_action_is_active(action), enabled);
   if (clicked) koncpc_menu_action(action);
   return clicked;
+}
+
+// Shared debugger step actions, so the DevTools toolbar buttons and the
+// keyboard shortcuts invoke identical behavior (beads-fa5).
+static void dbg_step_in() {
+  z80.step_in = 1;
+  z80.step_out = 0;
+  z80.step_out_addresses.clear();
+  cpc_resume();
+}
+static void dbg_step_over() {
+  z80.step_in = 0;
+  z80.step_out = 0;
+  z80.step_out_addresses.clear();
+  word pc = z80.PC.w.l;
+  if (z80_is_call_or_rst(pc)) {
+    z80_add_breakpoint_ephemeral(pc + z80_instruction_length(pc));
+    cpc_resume();
+  } else {
+    z80.step_in = 1;
+    cpc_resume();
+  }
+}
+static void dbg_step_out() {
+  z80.step_out = 1;
+  z80.step_out_addresses.clear();
+  z80.step_in = 0;
+  cpc_resume();
 }
 
 static void imgui_render_menubar() {
@@ -1923,8 +1962,7 @@ static void imgui_render_menu() {
 
   float bw = ImGui::GetContentRegionAvail().x;
 
-  ImGui::TextWrapped(
-      "Emulation paused. Use the menu bar above for all actions.");
+  ImGui::TextDisabled("PAUSED");
   ImGui::Spacing();
 
   // Enable keyboard navigation for this window (arrows/tab cycle buttons)
@@ -1935,14 +1973,54 @@ static void imgui_render_menu() {
   if (ImGui::Button("Resume (Esc)", ImVec2(bw, 0))) {
     action = true;
   }
-  if (ImGui::Button("Reset (F5/R)", ImVec2(bw, 0))) {
+
+  // Quick-load actions — same handlers as the Media menu, so F1 is a real hub
+  // rather than a dead-end that points back at the menu bar.
+  ImGui::Separator();
+  if (ImGui::Button("Load Disk...", ImVec2(bw, 0))) {
+    static const SDL_DialogFileFilter f[] = {
+        {"Disk Images", "dsk;ipf;raw;zip"}};
+    SDL_ShowOpenFileDialog(
+        file_dialog_callback,
+        reinterpret_cast<void*>(
+            static_cast<intptr_t>(FileDialogAction::LoadDiskA)),
+        mainSDLWindow, f, 1, CPC.current_dsk_path.c_str(), false);
+    action = true;
+  }
+  if (ImGui::Button("Load Tape...", ImVec2(bw, 0))) {
+    static const SDL_DialogFileFilter f[] = {{"Tape Images", "cdt;voc;zip"}};
+    SDL_ShowOpenFileDialog(
+        file_dialog_callback,
+        reinterpret_cast<void*>(
+            static_cast<intptr_t>(FileDialogAction::LoadTape)),
+        mainSDLWindow, f, 1, CPC.current_dsk_path.c_str(), false);
+    action = true;
+  }
+  if (ImGui::Button("Load Snapshot...", ImVec2(bw, 0))) {
+    static const SDL_DialogFileFilter f[] = {{"Snapshots", "sna;zip"}};
+    SDL_ShowOpenFileDialog(
+        file_dialog_callback,
+        reinterpret_cast<void*>(
+            static_cast<intptr_t>(FileDialogAction::LoadSnapshot)),
+        mainSDLWindow, f, 1, CPC.current_snap_path.c_str(), false);
+    action = true;
+  }
+  if (ImGui::Button("Options...", ImVec2(bw, 0))) {
+    imgui_state.show_options = true;
+  }
+
+  ImGui::Separator();
+  std::string reset_lbl =
+      "Reset (" + koncpc_action_shortcut(KONCPC_RESET) + ")";
+  if (ImGui::Button(reset_lbl.c_str(), ImVec2(bw, 0))) {
     emulator_reset();
     action = true;
   }
-  if (ImGui::Button("About (A)", ImVec2(bw, 0))) {
+  if (ImGui::Button("About", ImVec2(bw, 0))) {
     imgui_state.show_about = true;
   }
-  if (ImGui::Button("Quit (Q)", ImVec2(bw, 0))) {
+  std::string quit_lbl = "Quit (" + koncpc_action_shortcut(KONCPC_EXIT) + ")";
+  if (ImGui::Button(quit_lbl.c_str(), ImVec2(bw, 0))) {
     imgui_state.show_quit_confirm = true;
   }
 
@@ -1963,11 +2041,14 @@ static void imgui_render_menu() {
     ImGui::Text("Based on Caprice32 by Ulrich Doewich");
     ImGui::Spacing();
     ImGui::Text("Shortcuts:");
-    ImGui::BulletText("F1 - Menu");
-    ImGui::BulletText("Shift+F2 - DevTools");
-    ImGui::BulletText("F5 - Reset");
-    ImGui::BulletText("F10 - Quit");
-    ImGui::BulletText("F3 - Screenshot");
+    ImGui::BulletText("%s - Menu", koncpc_action_shortcut(KONCPC_GUI).c_str());
+    ImGui::BulletText("%s - DevTools",
+                      koncpc_action_shortcut(KONCPC_DEVTOOLS).c_str());
+    ImGui::BulletText("%s - Reset",
+                      koncpc_action_shortcut(KONCPC_RESET).c_str());
+    ImGui::BulletText("%s - Quit", koncpc_action_shortcut(KONCPC_EXIT).c_str());
+    ImGui::BulletText("%s - Screenshot",
+                      koncpc_action_shortcut(KONCPC_SCRNSHOT).c_str());
 #ifdef __APPLE__
     ImGui::BulletText("Cmd+K - Command Palette");
 #else
@@ -3112,41 +3193,19 @@ static void imgui_render_devtools() {
     // thread.
     bool was_paused = g_emu_paused.load(std::memory_order_relaxed);
     if (!was_paused) ImGui::BeginDisabled();
-    if (ImGui::Button("Step In")) {
-      z80.step_in = 1;
-      z80.step_out = 0;
-      z80.step_out_addresses.clear();
-      cpc_resume();
-    }
+    if (ImGui::Button("Step In")) dbg_step_in();
     if (ImGui::IsItemHovered()) {
-      ImGui::SetTooltip("Execute one instruction (enters CALLs)");
+      ImGui::SetTooltip("Execute one instruction, entering CALLs (F7)");
     }
     ImGui::SameLine();
-    if (ImGui::Button("Step Over")) {
-      z80.step_in = 0;
-      z80.step_out = 0;
-      z80.step_out_addresses.clear();
-      word pc = z80.PC.w.l;
-      if (z80_is_call_or_rst(pc)) {
-        z80_add_breakpoint_ephemeral(pc + z80_instruction_length(pc));
-        cpc_resume();
-      } else {
-        z80.step_in = 1;
-        cpc_resume();
-      }
-    }
+    if (ImGui::Button("Step Over")) dbg_step_over();
     if (ImGui::IsItemHovered()) {
-      ImGui::SetTooltip("Execute one instruction (skips over CALLs/RSTs)");
+      ImGui::SetTooltip("Execute one instruction, over CALLs/RSTs (Shift+F7)");
     }
     ImGui::SameLine();
-    if (ImGui::Button("Step Out")) {
-      z80.step_out = 1;
-      z80.step_out_addresses.clear();
-      z80.step_in = 0;
-      cpc_resume();
-    }
+    if (ImGui::Button("Step Out")) dbg_step_out();
     if (ImGui::IsItemHovered()) {
-      ImGui::SetTooltip("Run until the current subroutine returns");
+      ImGui::SetTooltip("Run until the current subroutine returns (Shift+F11)");
     }
     if (!was_paused) ImGui::EndDisabled();
     ImGui::SameLine();
@@ -3155,6 +3214,29 @@ static void imgui_render_devtools() {
         cpc_resume();
       else
         cpc_pause();
+    }
+    if (ImGui::IsItemHovered()) ImGui::SetTooltip("Run / halt the CPU (F5)");
+
+    // Keyboard shortcuts for the debugger inner loop.  Active only when an
+    // ImGui (DevTools) window holds keyboard focus and no text field is being
+    // edited; the emulator skips these keys then (any_keyboard_ui_active), so
+    // there is no conflict with the F-key emulator commands (beads-fa5).
+    {
+      ImGuiIO& io = ImGui::GetIO();
+      if (io.WantCaptureKeyboard && !io.WantTextInput) {
+        if (was_paused) {
+          if (ImGui::IsKeyChordPressed(ImGuiMod_Shift | ImGuiKey_F7))
+            dbg_step_over();
+          else if (ImGui::IsKeyChordPressed(ImGuiMod_Shift | ImGuiKey_F11))
+            dbg_step_out();
+          else if (ImGui::IsKeyPressed(ImGuiKey_F7, false))
+            dbg_step_in();
+          else if (ImGui::IsKeyPressed(ImGuiKey_F5, false))
+            cpc_resume();
+        } else if (ImGui::IsKeyPressed(ImGuiKey_F5, false)) {
+          cpc_pause();
+        }
+      }
     }
 
     // ── Per-window render timing ──

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -1327,12 +1327,9 @@ static void imgui_render_topbar() {
     }
 
     // ── Right status cluster: Layout button + (PAUSED | FPS) ──
-    // beads-ptu: group the Layout button and the status readout so they read as
-    // one right-aligned status zone, with a faint leading divider.
-    // ── Layout dropdown ──
-    // Uses a state-flag + standalone window instead of ImGui popup,
-    // because popups from the fixed topbar close immediately in docked
-    // mode due to focus interactions with the dockspace.
+    // Uses a state-flag + standalone window instead of ImGui popup, because
+    // popups from the fixed topbar close immediately in docked mode due to
+    // focus interactions with the dockspace.
     {
       // Right-align before rightmost element (PAUSED or FPS counter)
       float right_w = 0.0f;
@@ -1343,42 +1340,28 @@ static void imgui_render_topbar() {
       }
       float btn_w = ImGui::CalcTextSize("Layout").x +
                     ImGui::GetStyle().FramePadding.x * 2.0f;
-      // Reserve room for the leading divider + spacing (8px).
-      ImGui::SameLine(ImGui::GetWindowWidth() - right_w - btn_w - 12.0f - 8.0f);
+      ImGui::SameLine(ImGui::GetWindowWidth() - right_w - btn_w - 12.0f);
 
-      // Leading vertical separator marking the start of the status zone.
-      {
-        ImVec2 sc = ImGui::GetCursorScreenPos();
-        float frameH = ImGui::GetFrameHeight();
-        ImGui::GetWindowDrawList()->AddLine(
-            ImVec2(sc.x, sc.y + 3.0f), ImVec2(sc.x, sc.y + frameH - 3.0f),
-            IM_COL32(0x50, 0x50, 0x50, 0xFF), 1.0f);
-        ImGui::Dummy(ImVec2(1.0f, frameH));
-        ImGui::SameLine(0, 8.0f);
-      }
-
-      ImGui::BeginGroup();
       if (ImGui::Button("Layout")) {
         imgui_state.show_layout_dropdown = !imgui_state.show_layout_dropdown;
       }
       // Remember button position for dropdown window placement
       s_layout_btn_pos = ImGui::GetItemRectMin();
       s_layout_btn_pos.y = ImGui::GetItemRectMax().y + 2.0f;
+    }
 
-      if (is_paused) {
-        float pause_width = ImGui::CalcTextSize("PAUSED").x;
-        ImGui::SameLine(ImGui::GetWindowWidth() - pause_width - 8);
-        ImGui::AlignTextToFramePadding();
-        ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.8f, 0.2f, 1.0f));
-        ImGui::TextUnformatted("PAUSED");
-        ImGui::PopStyleColor();
-      } else if (!fps_display.empty()) {
-        float fps_width = ImGui::CalcTextSize(fps_display.c_str()).x;
-        ImGui::SameLine(ImGui::GetWindowWidth() - fps_width - 8);
-        ImGui::AlignTextToFramePadding();
-        ImGui::TextUnformatted(fps_display.c_str());
-      }
-      ImGui::EndGroup();
+    if (is_paused) {
+      float pause_width = ImGui::CalcTextSize("PAUSED").x;
+      ImGui::SameLine(ImGui::GetWindowWidth() - pause_width - 8);
+      ImGui::AlignTextToFramePadding();
+      ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.8f, 0.2f, 1.0f));
+      ImGui::TextUnformatted("PAUSED");
+      ImGui::PopStyleColor();
+    } else if (!fps_display.empty()) {
+      float fps_width = ImGui::CalcTextSize(fps_display.c_str()).x;
+      ImGui::SameLine(ImGui::GetWindowWidth() - fps_width - 8);
+      ImGui::AlignTextToFramePadding();
+      ImGui::TextUnformatted(fps_display.c_str());
     }
 
     // beads-sxd: subtle bottom separator so the native title bar, menu bar, and

--- a/src/keyboard.cpp
+++ b/src/keyboard.cpp
@@ -1,10 +1,12 @@
 #include "keyboard.h"
 
+#include <algorithm>
 #include <fstream>
 #include <iostream>
 #include <map>
 #include <set>
 #include <string>
+#include <vector>
 
 #include "fileutils.h"
 #include "koncepcja.h"
@@ -1549,6 +1551,43 @@ std::string InputMapper::CPCkeyToString(const CapriceKey cpc_key) {
     }
   }
   return "UNMAPPED(" + std::to_string(cpc_key) + ")";
+}
+
+namespace {
+// Format one host PCKey (modifier in the high dword, SDL keysym in the low) as
+// a readable accelerator string, e.g. "Shift+F2", "F5", "Pause".
+std::string format_pckey(PCKey pckey) {
+  SDL_Keycode key = static_cast<SDL_Keycode>(pckey & BITMASK_NOMOD);
+  PCKey mod = pckey >> BITSHIFT_MOD;
+  std::string s;
+  if (mod & SDL_KMOD_CTRL) s += "Ctrl+";
+  if (mod & SDL_KMOD_SHIFT) s += "Shift+";
+  const char* name = SDL_GetKeyName(key);
+  s += (name != nullptr && *name != '\0') ? name : "?";
+  return s;
+}
+}  // namespace
+
+std::string InputMapper::shortcutForAction(CapriceKey action) const {
+  std::vector<std::string> parts;
+  for (const auto& [pckey, capkey] : CPCkeysFromSDLkeysym) {
+    if (capkey == action) parts.push_back(format_pckey(pckey));
+  }
+  std::sort(parts.begin(), parts.end());
+  parts.erase(std::unique(parts.begin(), parts.end()), parts.end());
+  std::string out;
+  for (size_t i = 0; i < parts.size(); ++i) {
+    if (i != 0) out += " / ";
+    out += parts[i];
+  }
+  return out;
+}
+
+// Keystone helper: derive an action's shortcut DISPLAY string from the live
+// binding map, so every surface's hint stays truthful automatically.
+std::string koncpc_action_shortcut(KONCPC_KEYS action) {
+  if (CPC.InputMapper == nullptr) return "";
+  return CPC.InputMapper->shortcutForAction(static_cast<CapriceKey>(action));
 }
 
 std::list<SDL_Event> InputMapper::StringToEvents(std::string toTranslate) {

--- a/src/keyboard.h
+++ b/src/keyboard.h
@@ -337,4 +337,13 @@ class InputMapper {
                                    bool& release);
   std::list<SDL_Event> StringToEvents(std::string toTranslate);
   void set_joystick_emulation();
+  // Human-readable host shortcut(s) currently bound to an emulator command,
+  // derived from the live binding map so menu/UI hints can never drift from the
+  // real keys.  Returns e.g. "F5", "Shift+F2 / F12", or "" if unbound.
+  std::string shortcutForAction(CapriceKey action) const;
 };
+
+// Keystone helper: the single source of truth for an action's shortcut DISPLAY
+// string, derived from the real binding (not hand-typed per surface).  Every
+// menu/topbar/popup/command-palette surface renders hints via this.
+std::string koncpc_action_shortcut(KONCPC_KEYS action);

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -3810,6 +3810,16 @@ static void z80_thread_main() {
         dwFrameCount = 0;
         perfTicksTargetFPS = perfNow + perfFreq;
 
+        // Opt-in once-per-second FPS log (run with --debug/-v) — a passive,
+        // tail-able steady-FPS readout that doesn't perturb the emulation the
+        // way an IPC `wait vbl` probe does.
+        if (g_debug) {
+          printf(
+              "[fps] %3u FPS  %3u%% speed\n", dwFPS,
+              dwFPS * 100u / static_cast<unsigned>(1000.0 / FRAME_PERIOD_MS));
+          fflush(stdout);
+        }
+
         {
           std::lock_guard<std::mutex> stats_lock(g_imgui_stats_mutex);
           if (frameTimeSamples > 0) {

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -150,6 +150,7 @@ video_plugin* vid_plugin;
 static bool g_take_screenshot = false;
 bool g_headless = false;
 bool g_debug = false;
+bool g_log_fps = false;  // --fps: log once-per-second FPS to stdout
 static bool g_exit_on_break = false;
 static enum { EXIT_NONE, EXIT_FRAMES, EXIT_MS } g_exit_mode = EXIT_NONE;
 static dword g_exit_target = 0;
@@ -3810,10 +3811,10 @@ static void z80_thread_main() {
         dwFrameCount = 0;
         perfTicksTargetFPS = perfNow + perfFreq;
 
-        // Opt-in once-per-second FPS log (run with --debug/-v) — a passive,
-        // tail-able steady-FPS readout that doesn't perturb the emulation the
-        // way an IPC `wait vbl` probe does.
-        if (g_debug) {
+        // Opt-in once-per-second FPS log (run with --fps, or --debug) — a
+        // passive, tail-able steady-FPS readout that doesn't perturb the
+        // emulation the way an IPC `wait vbl` probe does.
+        if (g_log_fps || g_debug) {
           printf(
               "[fps] %3u FPS  %3u%% speed\n", dwFPS,
               dwFPS * 100u / static_cast<unsigned>(1000.0 / FRAME_PERIOD_MS));
@@ -4192,6 +4193,7 @@ int koncpc_main(int argc, char** argv) {
   parseArguments(argc, argv, slot_list, args);
   g_headless = args.headless;
   g_debug = args.debug;
+  g_log_fps = args.fps;
   g_exit_on_break = args.exitOnBreak;
 
   // Parse --exit-after spec: Nf (frames), Ns (seconds), Nms (milliseconds)

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -1500,6 +1500,16 @@ void emulator_reset() {
     memcpy(pbMF2ROM, pbMF2ROMbackup,
            8192);  // copy the MF2 ROM to its proper place
   }
+
+  // The first reset happens during emulator_init() (boot), where an OSD
+  // message would be wrong / premature. Suppress feedback on that very first
+  // call; every subsequent (user-initiated) reset shows confirmation.
+  static bool first_reset = true;
+  if (first_reset) {
+    first_reset = false;
+  } else {
+    set_osd_message("Machine reset");
+  }
 }
 
 int input_init() {
@@ -3070,6 +3080,7 @@ void dumpScreen() {
   LOG_INFO("Dumping screen to " + dumpPath);
   if (!dumpScreenTo(dumpPath)) {
     LOG_ERROR("Could not write screenshot file to " + dumpPath);
+    set_osd_message("Screenshot failed");
   } else {
     set_osd_message("Captured " + dumpFile);
   }
@@ -3089,6 +3100,7 @@ void dumpSnapshot() {
   LOG_INFO("Dumping machine snapshot to " + dumpPath);
   if (snapshot_save(dumpPath)) {
     LOG_ERROR("Could not write machine snapshot to " + dumpPath);
+    set_osd_message("Snapshot save failed");
   } else {
     set_osd_message("Snapshotted " + dumpFile);
   }
@@ -3100,6 +3112,9 @@ void loadSnapshot() {
   LOG_INFO("Loading snapshot from " + lastSavedSnapshot);
   if (snapshot_load(lastSavedSnapshot)) {
     LOG_ERROR("Could not load machine snapshot from " + lastSavedSnapshot);
+    std::string dirname, filename;
+    stringutils::splitPath(lastSavedSnapshot, dirname, filename);
+    set_osd_message("Snapshot load failed: " + filename);
   } else {
     std::string dirname, filename;
     stringutils::splitPath(lastSavedSnapshot, dirname, filename);

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -278,6 +278,13 @@ dword freq_table[MAX_FREQ_ENTRIES] = {11025, 22050, 44100, 48000, 96000};
 void set_osd_message(const std::string& message, uint32_t for_milliseconds) {
   osd_timing = SDL_GetTicks() + for_milliseconds;
   osd_message = " " + message;
+  // Unify feedback channels (beads-49l): in GUI mode also surface the message
+  // as a toast, so the same action gives consistent feedback whether it was
+  // triggered by a shortcut/menu (this OSD path) or a file dialog (which
+  // toasts directly).  Headless keeps the OSD-only behavior.
+  if (!g_headless) {
+    ui_host().toast(UiToastLevel::Info, message);
+  }
 }
 
 double colours_rgb[32][3] = {

--- a/src/macos_menu.mm
+++ b/src/macos_menu.mm
@@ -17,79 +17,17 @@ extern "C" void koncpc_menu_action(int action);
   NSInteger action = [sender tag];
   koncpc_menu_action(static_cast<int>(action));
 }
-@end
-
-static void applyShortcut(NSMenuItem* item, const char* shortcut) {
-  if (!shortcut || !shortcut[0]) return;
-  NSString* s = [NSString stringWithUTF8String:shortcut];
-  NSString* upper = [s uppercaseString];
-  NSEventModifierFlags mods = 0;
-  if ([upper containsString:@"SHIFT+"]) mods |= NSEventModifierFlagShift;
-  if ([upper containsString:@"CMD+"] || [upper containsString:@"COMMAND+"])
-    mods |= NSEventModifierFlagCommand;
-  if ([upper containsString:@"ALT+"] || [upper containsString:@"OPTION+"])
-    mods |= NSEventModifierFlagOption;
-  if ([upper containsString:@"CTRL+"] || [upper containsString:@"CONTROL+"])
-    mods |= NSEventModifierFlagControl;
-
-  // Extract the key part after all modifiers (everything after the last '+')
-  NSRange lastPlus = [upper rangeOfString:@"+" options:NSBackwardsSearch];
-  NSString* keyPart =
-      (lastPlus.location != NSNotFound) ? [upper substringFromIndex:lastPlus.location + 1] : upper;
-
-  unichar key = 0;
-  if ([keyPart hasPrefix:@"F"] && [keyPart length] >= 2) {
-    NSInteger fn = [[keyPart substringFromIndex:1] integerValue];
-    switch (fn) {
-      case 1:
-        key = NSF1FunctionKey;
-        break;
-      case 2:
-        key = NSF2FunctionKey;
-        break;
-      case 3:
-        key = NSF3FunctionKey;
-        break;
-      case 4:
-        key = NSF4FunctionKey;
-        break;
-      case 5:
-        key = NSF5FunctionKey;
-        break;
-      case 6:
-        key = NSF6FunctionKey;
-        break;
-      case 7:
-        key = NSF7FunctionKey;
-        break;
-      case 8:
-        key = NSF8FunctionKey;
-        break;
-      case 9:
-        key = NSF9FunctionKey;
-        break;
-      case 10:
-        key = NSF10FunctionKey;
-        break;
-      case 11:
-        key = NSF11FunctionKey;
-        break;
-      case 12:
-        key = NSF12FunctionKey;
-        break;
-      default:
-        break;
-    }
-  } else if ([keyPart isEqualToString:@"PAUSE"]) {
-    key = NSPauseFunctionKey;
+// Queried by AppKit each time the menu opens, so toggle items show a live
+// checkmark from the single source of truth instead of no state at all.
+- (BOOL)validateMenuItem:(NSMenuItem*)item {
+  const MenuAction* entry = koncpc_find_action(static_cast<KONCPC_KEYS>([item tag]));
+  if (entry != nullptr && entry->toggle) {
+    [item setState:koncpc_action_is_active(entry->action) ? NSControlStateValueOn
+                                                          : NSControlStateValueOff];
   }
-
-  if (key) {
-    NSString* ke = [NSString stringWithCharacters:&key length:1];
-    [item setKeyEquivalent:ke];
-    [item setKeyEquivalentModifierMask:mods];
-  }
+  return YES;
 }
+@end
 
 static const MenuAction* find_menu_action(KONCPC_KEYS action) {
   for (const auto& entry : koncpc_menu_actions()) {
@@ -111,12 +49,18 @@ static void add_menu_group(NSMenu* mainMenu, KoncepcjaMenuTarget* target, NSStri
     const MenuAction* entry = find_menu_action(action);
     if (!entry) continue;
     NSString* itemTitle = [NSString stringWithUTF8String:entry->title];
+    // Show the real shortcut as TEXT only (no keyEquivalent): SDL owns every
+    // key, so registering an AppKit accelerator here would double-fire the
+    // action.  The hint is derived from the live binding, so it can't drift.
+    std::string sc = koncpc_action_shortcut(entry->action);
+    if (!sc.empty()) {
+      itemTitle = [itemTitle stringByAppendingFormat:@"  (%s)", sc.c_str()];
+    }
     NSMenuItem* item = [[NSMenuItem alloc] initWithTitle:itemTitle
                                                   action:@selector(menuAction:)
                                            keyEquivalent:@""];
     [item setTarget:target];
     [item setTag:static_cast<NSInteger>(entry->action)];
-    applyShortcut(item, entry->shortcut);
     [submenu addItem:item];
   }
 

--- a/src/menu_actions.cpp
+++ b/src/menu_actions.cpp
@@ -1,26 +1,39 @@
 #include "menu_actions.h"
 
+// Canonical label + toggle metadata for every emulator action.  Shortcut hints
+// are intentionally NOT stored here — every surface derives them from the live
+// binding via koncpc_action_shortcut() so a label can never drift from its key.
+// One canonical label per action, shared by the native menu, ImGui menus, the
+// F1 popup and the command palette.
 const std::vector<MenuAction>& koncpc_menu_actions() {
   static const std::vector<MenuAction> actions = {
-      {KONCPC_GUI, "Menu", ""},
-      {KONCPC_VKBD, "Virtual Keyboard", ""},
-      {KONCPC_FULLSCRN, "Fullscreen", ""},
-      {KONCPC_DEVTOOLS, "DevTools", ""},
-      {KONCPC_SCRNSHOT, "Screenshot", ""},
-      {KONCPC_SNAPSHOT, "Save Snapshot", ""},
-      {KONCPC_TAPEPLAY, "Tape Play", ""},
-      {KONCPC_LD_SNAP, "Load Snapshot", ""},
-      {KONCPC_RESET, "Reset", ""},
-      {KONCPC_NEXTDISKA, "Next A: Disk in ZIP", ""},
-      {KONCPC_MF2STOP, "MF2 Stop", ""},
-      {KONCPC_JOY, "Toggle Joystick Emulation", ""},
-      {KONCPC_PHAZER, "Toggle Phazer Emulation", ""},
-      {KONCPC_FPS, "Toggle FPS", ""},
-      {KONCPC_SPEED, "Toggle Speed Limit", ""},
-      {KONCPC_EXIT, "Quit", ""},
-      {KONCPC_PASTE, "Paste", ""},
-      {KONCPC_DELAY, "Delay", ""},
-      {KONCPC_WAITBREAK, "Wait Break", ""},
+      {KONCPC_GUI, "Menu", "", false},
+      {KONCPC_VKBD, "Virtual Keyboard", "", false},
+      {KONCPC_FULLSCRN, "Fullscreen", "", false},
+      {KONCPC_DEVTOOLS, "DevTools", "", true},
+      {KONCPC_SCRNSHOT, "Screenshot", "", false},
+      {KONCPC_SNAPSHOT, "Save Snapshot", "", false},
+      {KONCPC_TAPEPLAY, "Tape Play/Stop", "", false},
+      {KONCPC_LD_SNAP, "Load Snapshot", "", false},
+      {KONCPC_RESET, "Reset", "", false},
+      {KONCPC_NEXTDISKA, "Next A: Disk in ZIP", "", false},
+      {KONCPC_MF2STOP, "MF2 Stop", "", false},
+      {KONCPC_JOY, "Joystick Emulation", "", true},
+      {KONCPC_PHAZER, "Phazer Emulation", "", true},
+      {KONCPC_FPS, "Show FPS", "", true},
+      {KONCPC_SPEED, "Limit Speed", "", true},
+      {KONCPC_DEBUG, "Verbose Logging", "", true},
+      {KONCPC_EXIT, "Quit", "", false},
+      {KONCPC_PASTE, "Paste", "", false},
+      {KONCPC_DELAY, "Delay", "", false},
+      {KONCPC_WAITBREAK, "Wait Break", "", false},
   };
   return actions;
+}
+
+const MenuAction* koncpc_find_action(KONCPC_KEYS action) {
+  for (const MenuAction& a : koncpc_menu_actions()) {
+    if (a.action == action) return &a;
+  }
+  return nullptr;
 }

--- a/src/menu_actions.h
+++ b/src/menu_actions.h
@@ -4,10 +4,23 @@
 
 #include "keyboard.h"
 
+// Single source of truth for an emulator action's UI metadata.  The shortcut
+// hint is NOT stored here — it is derived from the live binding via
+// koncpc_action_shortcut() so labels can never drift from the real keys.
 struct MenuAction {
   KONCPC_KEYS action;
-  const char* title;
-  const char* shortcut;  // human-readable, e.g. "F5" or "Shift+F2"
+  const char* title;     // ONE canonical label, used by every surface
+  const char* shortcut;  // DEPRECATED/transitional; always "" — use
+                         // koncpc_action_shortcut(action) for the real hint
+  bool toggle;  // true => the action flips a state shown as a checkmark
 };
 
 const std::vector<MenuAction>& koncpc_menu_actions();
+
+// Look up an action's metadata by id, or nullptr if it has no entry.
+const MenuAction* koncpc_find_action(KONCPC_KEYS action);
+
+// Live toggle state for a toggle-kind action (checkmark in menus).  Defined in
+// the GUI translation unit (imgui_ui.cpp) since it reads GUI/emulator globals;
+// returns false for non-toggle actions or in non-GUI builds.
+bool koncpc_action_is_active(KONCPC_KEYS action);

--- a/src/workspace_layout.cpp
+++ b/src/workspace_layout.cpp
@@ -235,11 +235,9 @@ void workspace_apply_preset(WorkspacePreset preset) {
       ImGui::DockBuilderDockWindow("Breakpoints & Watchpoints & IO###BPWindow",
                                    bottom);
 
-      ensure_window_open("registers");
-      ensure_window_open("disassembly");
-      ensure_window_open("stack");
-      ensure_window_open("breakpoints");
-      ensure_window_open("memory_hex");
+      // Open the core debugging window set — same list the F12 auto-open path
+      // uses, so the two can't drift (beads-igq).
+      g_devtools_ui.open_core_debug_windows();
       break;
     }
 

--- a/test/InputMapper.cpp
+++ b/test/InputMapper.cpp
@@ -124,3 +124,26 @@ TEST_F(InputMapperTest, Keymapping) {
             CPC.InputMapper->CPCscancodeFromKeysym(
                 static_cast<SDL_Keycode>(241), SDL_KMOD_LSHIFT));
 }
+
+// Keystone: shortcut display strings are derived from the live binding map, so
+// menu/UI hints can never drift from the real keys.
+TEST_F(InputMapperTest, ShortcutForActionDerivesFromBindings) {
+  CPC.kbd_layout = "keymap_us.map";
+  CPC.keyboard = 0;
+  CPC.InputMapper->init();
+
+  // Single-binding emulator commands.
+  EXPECT_EQ("F5", CPC.InputMapper->shortcutForAction(KONCPC_RESET));
+  EXPECT_EQ("F10", CPC.InputMapper->shortcutForAction(KONCPC_EXIT));
+  EXPECT_EQ("F8", CPC.InputMapper->shortcutForAction(KONCPC_FPS));
+
+  // DevTools' real key after the US keymap loads is F12 (the keymap entry
+  // overwrites the base Shift+F2 binding in the forward map).  The derived
+  // string reports the TRUE binding — this is exactly why menu labels that
+  // still say "Shift+F2" are wrong and must render from this helper instead.
+  EXPECT_EQ("F12", CPC.InputMapper->shortcutForAction(KONCPC_DEVTOOLS));
+
+  // The free-function wrapper used by every UI surface agrees.
+  EXPECT_EQ(CPC.InputMapper->shortcutForAction(KONCPC_RESET),
+            koncpc_action_shortcut(KONCPC_RESET));
+}


### PR DESCRIPTION
## UX reshape — single source of truth + Core UI / DevTools cleanup

Implements **30 of 34** findings from a multi-agent UX review of konCePCja's Core UI and DevTools (epic `beads-4ll`). One coherent reshape, built around a keystone refactor that dissolved the biggest theme.

> **Base note:** stacked on `fix/input-bugs-cluster` (PR #136). Review/merge #136 first; this retargets to `master` once #136 lands.

### Keystone — single source of truth for actions
- `menu_actions.cpp` holds one canonical label + toggle-state per action; the **shortcut hint is derived from the live key binding** (`koncpc_action_shortcut`) so labels can never drift from keys again.
- Every surface renders through it: ImGui menu bar + command palette via `RenderMenuItem`, native macOS menu via `validateMenuItem:` (live check-marks) and derived shortcut **text** (no `keyEquivalent` → SDL stays the single key source, no double-fire).
- Dissolved: DevTools triple-placement (3→1), "Memory Tool"/"Toggle FPS"/"Tape Play" label drift, missing native check-marks. (`cb4a14d`, `12214f8`, `fa0c117`)

### P0s
- **Quit data-loss guard** — the GUI quit modal now warns about unsaved disk changes (it passed `askIfUnsaved=false`, bypassing the native guard the window-close path enforces); + Esc-to-cancel and safe default focus.
- **Debugger keyboard step shortcuts** — F7 / Shift+F7 / Shift+F11 Step In/Over/Out, F5 Run/Halt (active when DevTools holds keyboard focus; emulator yields keys then, no conflict).

### Core UI
F1 popup reworked from an empty "use the menu bar" nag into a real quick-action hub (Load Disk/Tape/Snapshot, Options); topbar polish (separator, consistent button affordance, grouped status cluster, "·" FPS readout); first-run load hint; Command Palette surfaced in the menu; unified feedback (OSD also toasts in GUI mode); silent-failure and reset feedback. (`650c0cb`, `9300213`, `85246c9`)

### DevTools
Run/paused state chips; register right-click → View in Memory/Disassembly; greyed-while-running registers with a "pause to edit" hint; reflowing register table; breakpoint gutter (left-click no longer toggles BPs); add-breakpoint-by-address; staggered default window positions (no more cascade/off-screen drift); **Reset Window Positions** + preset dropdown in the DevTools toolbar. (`650c0cb`, `9300213`, `6b90041`)

### Verification
- macOS build clean; **full unit suite 1132 tests pass**; clang-format clean (Linux gate); menus / topbar / feedback visually verified via screenshots.

### Deferred (4, tracked with notes)
- `beads-4i4` (P1) — **mitigated** by the step keyboard shortcuts; a redundant in-disasm toolbar is low value.
- `beads-ar4` (P2) — viewport-aware toast rendering (multi-viewport).
- `beads-34s` (P2) — CPC-screen host padding; GL screen-draw path is entangled, deferred to avoid render-path risk.
- `beads-bqx` (P3) — native-menu shortcut-text suffix init-ordering.
