### PR TITLE
feat(ipc): mouse input over IPC + input-command doc fixes + device tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,22 @@ echo "help" | nc localhost 6543
 | `snapshot load <path>` | Load state | `snapshot load game.sna` |
 | `load <path>` | Load file (.dsk/.sna/.cpr/.bin) | `load game.dsk` |
 | `devtools` | Open DevTools window | `devtools` → `OK` |
+| `input keydown <name>` | Press and hold a key | `input keydown SHIFT` |
+| `input keyup <name>` | Release a key | `input keyup SHIFT` |
+| `input key <name>` | Tap a key (press, hold 2 frames, release) | `input key RETURN` |
+| `input type <text>` | Type literal text (mapped chars only, no `~KEY~`) | `input type 'mode 1'` |
+| `input joy <0\|1> <dir>` | Joystick dir (U/D/L/R/F1/F2, `0`=release all, `-`=release one) | `input joy 0 F1` |
+| `input mouse move <dx> <dy>` | Relative mouse motion (needs AMX/Symbiface mouse enabled) | `input mouse move 10 -4` |
+| `input mouse button <L\|M\|R> <down\|up>` | Press/release a mouse button | `input mouse button L down` |
+| `input mouse buttons <mask>` | Set whole SDL button mask (L=1,M=2,R=4) | `input mouse buttons 0` |
+| `autotype <text>` | Queue text via AutoTypeQueue (supports WinAPE `~KEY~`) | `autotype 'run"game~RETURN~'` |
+| `autotype status` | Show pending queue length | `autotype status` |
+| `autotype clear` | Cancel pending input | `autotype clear` |
+
+`<name>` is a friendly key name (`RETURN`, `SPACE`, `ESC`, `F1`, `UP`, ...) or a
+single character (`a`, `A`, `1`). For multi-line entry or special keys inside a
+string, use `autotype` with `~KEY~` tokens — `input type` does **not** interpret
+them.
 
 ### Scripting Example
 

--- a/README.md
+++ b/README.md
@@ -39,12 +39,21 @@ konCePCja is a fork of [Caprice32](https://github.com/ColinPitrat/caprice32) wit
   * **IPC protocol** — TCP server on port 6543 for remote control by scripts and LLM agents
   * **Telnet console** — persistent TCP text terminal on port 6544, mirrors CPC output and accepts keyboard input (`nc localhost 6544`)
   * **Headless mode** (`--headless`) — run without a window for CI and automation
-  * **Input replay** — type text, press keys and control joysticks over IPC
+  * **Input replay** — type text, press keys, drive joysticks and the mouse over IPC
   * **Auto-Type** — `autotype` command with WinAPE `~KEY~` syntax for scripted keyboard input
   * **Frame stepping** — advance exact frame counts for deterministic testing
   * **Exit control** — `--exit-after`, `--exit-on-break` and `quit` for scripted runs
   * **Hash commands** — CRC32 of VRAM, memory ranges and registers for CI assertions
   * **Event system** — fire IPC commands on PC match, memory write or VBL interval
+
+For example, type and run a BASIC program over the IPC socket:
+
+```bash
+echo 'input type "10 print \"hello\""' | nc -w 2 localhost 6543
+echo 'input key RETURN'                | nc -w 2 localhost 6543
+echo 'autotype "run~RETURN~"'          | nc -w 2 localhost 6543   # ~KEY~ via autotype
+echo 'input mouse move 10 -4'          | nc -w 2 localhost 6543   # needs a mouse device
+```
 
 ### Debugger
   * **Breakpoints** with conditional expressions (`if A > #10 and peek(HL) = #C9`) and pass counts

--- a/docs/ipc-protocol.md
+++ b/docs/ipc-protocol.md
@@ -277,6 +277,11 @@ Single characters work directly: `A`-`Z`, `a`-`z`, `0`-`9`, punctuation.
 | `input key <key>` | Tap: press, hold 2 frames, release. Blocks. |
 | `input type "<text>"` | Type each character with 2-frame hold and 1-frame gap. Handles uppercase (auto-SHIFT). Blocks. |
 | `input joy <n> <dir>` | Joystick N (0 or 1). Directions: `U`/`UP` `D`/`DOWN` `L`/`LEFT` `R`/`RIGHT` `F`/`F1`/`FIRE1` `F2`/`FIRE2`. Prefix `-` to release. `0` releases all. |
+| `input mouse move <dx> <dy>` | Relative mouse motion (mickeys) fed to the AMX/Symbiface mouse. Requires a mouse device enabled (`input.amx_mouse=1` or `peripheral.symbiface=1`), else `ERR 409`. |
+| `input mouse button <L\|M\|R> <down\|up>` | Press/release one mouse button. |
+| `input mouse buttons <mask>` | Set the whole SDL button mask at once (Left=1, Middle=2, Right=4). |
+
+> **Note:** `input type` emits only mapped characters — it does *not* interpret WinAPE `~KEY~` tokens. Use the `autotype` command for special keys, holds, and multi-line entry.
 
 ### Example: Type and run a BASIC program
 

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -4220,6 +4220,7 @@ bool render_one_frame() {
     video_display_b();
     video_take_pending_window_screenshot();
     if (g_m4_http.is_running()) g_m4_http.drain_pending();
+    ipc_drain_input();
     std::this_thread::sleep_for(std::chrono::milliseconds(POLL_INTERVAL_MS));
     return false;
   }
@@ -4277,6 +4278,7 @@ bool render_one_frame() {
   // stalls on present. Removed.
   // Main-thread-only housekeeping
   if (g_m4_http.is_running()) g_m4_http.drain_pending();
+  ipc_drain_input();
 #ifdef __APPLE__
   // Dock preview reads the just-presented frame (render-thread-private
   // after video_ring_present's copy), NOT the Z80's live write buffer.
@@ -5232,6 +5234,9 @@ int koncpc_main(int argc, char** argv) {
         // M4 HTTP server — drain deferred actions (reset, pause toggle)
         if (g_m4_http.is_running()) g_m4_http.drain_pending();
 
+        // IPC mouse input — flush staged deltas/buttons into the devices
+        ipc_drain_input();
+
 #ifdef __APPLE__
         // Update Dock icon with CPC screen preview (~1fps at 50fps emulation)
         // back_surface is already sized to CPC_VISIBLE_SCR_WIDTH/HEIGHT * scale
@@ -5434,6 +5439,7 @@ int koncpc_main(int argc, char** argv) {
       // Drain HTTP deferred actions even while paused (otherwise resume won't
       // work)
       if (g_m4_http.is_running()) g_m4_http.drain_pending();
+      ipc_drain_input();
       std::this_thread::sleep_for(std::chrono::milliseconds(POLL_INTERVAL_MS));
     }
 

--- a/src/koncepcja_ipc_server.cpp
+++ b/src/koncepcja_ipc_server.cpp
@@ -18,6 +18,7 @@
 #include <functional>
 #include <iomanip>
 #include <map>
+#include <mutex>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -237,24 +238,40 @@ static void ipc_apply_keypress(CPCScancode cpc_key,
 // used by g_m4_http.drain_pending() and g_repaint_pending.
 namespace {
 struct IpcMousePending {
-  std::atomic<int32_t> dx{0};
-  std::atomic<int32_t> dy{0};
-  std::atomic<uint32_t> buttons{0};  // SDL button mask (Left=1, Middle=2, Right=4)
-  std::atomic<bool> dirty{false};
+  std::mutex mutex;  // guards the dx/dy/buttons group as one snapshot
+  int32_t dx{0};
+  int32_t dy{0};
+  uint32_t buttons{0};  // SDL button mask (Left=1, Middle=2, Right=4)
+  std::atomic<bool> dirty{false};  // fast-path: skip the lock when idle
 };
 IpcMousePending g_ipc_mouse;
 }  // namespace
 
 // Drained once per frame on the main thread.  Safe no-op when no mouse input is
-// pending or no mouse device is enabled.
+// pending or no mouse device is enabled.  The lock is held only to copy the
+// dx/dy/buttons group into a local snapshot and reset the accumulators, so dx
+// and dy can never come from different updates (no shearing); the device
+// updates run unlocked.
 void ipc_drain_input() {
-  if (!g_ipc_mouse.dirty.exchange(false, std::memory_order_acquire)) return;
-  auto dx = static_cast<float>(g_ipc_mouse.dx.exchange(0, std::memory_order_relaxed));
-  auto dy = static_cast<float>(g_ipc_mouse.dy.exchange(0, std::memory_order_relaxed));
-  uint32_t buttons = g_ipc_mouse.buttons.load(std::memory_order_relaxed);
+  if (!g_ipc_mouse.dirty.load(std::memory_order_acquire)) return;
+  int32_t dx = 0;
+  int32_t dy = 0;
+  uint32_t buttons = 0;
+  {
+    std::lock_guard<std::mutex> lock(g_ipc_mouse.mutex);
+    if (!g_ipc_mouse.dirty.load(std::memory_order_relaxed)) return;
+    dx = g_ipc_mouse.dx;
+    dy = g_ipc_mouse.dy;
+    buttons = g_ipc_mouse.buttons;
+    g_ipc_mouse.dx = 0;
+    g_ipc_mouse.dy = 0;
+    g_ipc_mouse.dirty.store(false, std::memory_order_relaxed);
+  }
+  auto f_dx = static_cast<float>(dx);
+  auto f_dy = static_cast<float>(dy);
   // Feed whichever device(s) are active; SDL feeds both the same way.
-  if (g_amx_mouse.enabled) amx_mouse_update(dx, dy, buttons);
-  if (g_symbiface.enabled) symbiface_mouse_update(dx, dy, buttons);
+  if (g_amx_mouse.enabled) amx_mouse_update(f_dx, f_dy, buttons);
+  if (g_symbiface.enabled) symbiface_mouse_update(f_dx, f_dy, buttons);
 }
 
 static bool has_path_traversal(const std::string& path) {
@@ -2290,10 +2307,9 @@ std::string handle_command(const std::string& line) {
         if (!g_amx_mouse.enabled && !g_symbiface.enabled)
           return "ERR 409 no-mouse-device (enable AMX or Symbiface mouse)\n";
         if (parts[2] == "move" && parts.size() >= 5) {
-          g_ipc_mouse.dx.fetch_add(parse_int(parts[3]),
-                                   std::memory_order_relaxed);
-          g_ipc_mouse.dy.fetch_add(parse_int(parts[4]),
-                                   std::memory_order_relaxed);
+          std::lock_guard<std::mutex> lock(g_ipc_mouse.mutex);
+          g_ipc_mouse.dx += parse_int(parts[3]);
+          g_ipc_mouse.dy += parse_int(parts[4]);
           g_ipc_mouse.dirty.store(true, std::memory_order_release);
           return "OK\n";
         }
@@ -2310,19 +2326,21 @@ std::string handle_command(const std::string& line) {
             bit = 4u;  // SDL_BUTTON_RMASK
           else
             return "ERR 400 bad-button (L|M|R)\n";
-          if (parts[4] == "down")
-            g_ipc_mouse.buttons.fetch_or(bit, std::memory_order_relaxed);
-          else if (parts[4] == "up")
-            g_ipc_mouse.buttons.fetch_and(~bit, std::memory_order_relaxed);
-          else
-            return "ERR 400 bad-button-state (down|up)\n";
-          g_ipc_mouse.dirty.store(true, std::memory_order_release);
+          {
+            std::lock_guard<std::mutex> lock(g_ipc_mouse.mutex);
+            if (parts[4] == "down")
+              g_ipc_mouse.buttons |= bit;
+            else if (parts[4] == "up")
+              g_ipc_mouse.buttons &= ~bit;
+            else
+              return "ERR 400 bad-button-state (down|up)\n";
+            g_ipc_mouse.dirty.store(true, std::memory_order_release);
+          }
           return "OK\n";
         }
         if (parts[2] == "buttons" && parts.size() >= 4) {
-          g_ipc_mouse.buttons.store(
-              static_cast<uint32_t>(parse_int(parts[3])),
-              std::memory_order_relaxed);
+          std::lock_guard<std::mutex> lock(g_ipc_mouse.mutex);
+          g_ipc_mouse.buttons = static_cast<uint32_t>(parse_int(parts[3]));
           g_ipc_mouse.dirty.store(true, std::memory_order_release);
           return "OK\n";
         }

--- a/src/koncepcja_ipc_server.cpp
+++ b/src/koncepcja_ipc_server.cpp
@@ -47,6 +47,7 @@
 #include "disk_format.h"
 #include "disk_sector_editor.h"
 #include "drive_status.h"
+#include "amx_mouse.h"
 #include "expr_parser.h"
 #include "gif_recorder.h"
 #include "imgui_ui_testable.h"
@@ -60,6 +61,7 @@
 #include "session_recording.h"
 #include "silicon_disc.h"
 #include "slotshandler.h"
+#include "symbiface.h"
 #include "symfile.h"
 #include "trace.h"
 #include "video.h"
@@ -224,6 +226,35 @@ static void ipc_apply_keypress(CPCScancode cpc_key,
     keyboard_matrix[0x27 >> 4].fetch_or(bit_values[0x27 & 7],
                                         std::memory_order_relaxed);
   }
+}
+
+// Mouse input staging.  IPC commands run on the server thread, but the mouse
+// devices (AMX, Symbiface PS/2) keep non-atomic accumulators that the main
+// thread reads.  So instead of poking them directly, IPC accumulates relative
+// deltas + the current button mask here, and ipc_drain_input() (called once per
+// frame on the main thread) flushes them through the same amx_mouse_update() /
+// symbiface_mouse_update() entry points SDL uses.  Mirrors the deferral pattern
+// used by g_m4_http.drain_pending() and g_repaint_pending.
+namespace {
+struct IpcMousePending {
+  std::atomic<int32_t> dx{0};
+  std::atomic<int32_t> dy{0};
+  std::atomic<uint32_t> buttons{0};  // SDL button mask (Left=1, Middle=2, Right=4)
+  std::atomic<bool> dirty{false};
+};
+IpcMousePending g_ipc_mouse;
+}  // namespace
+
+// Drained once per frame on the main thread.  Safe no-op when no mouse input is
+// pending or no mouse device is enabled.
+void ipc_drain_input() {
+  if (!g_ipc_mouse.dirty.exchange(false, std::memory_order_acquire)) return;
+  auto dx = static_cast<float>(g_ipc_mouse.dx.exchange(0, std::memory_order_relaxed));
+  auto dy = static_cast<float>(g_ipc_mouse.dy.exchange(0, std::memory_order_relaxed));
+  uint32_t buttons = g_ipc_mouse.buttons.load(std::memory_order_relaxed);
+  // Feed whichever device(s) are active; SDL feeds both the same way.
+  if (g_amx_mouse.enabled) amx_mouse_update(dx, dy, buttons);
+  if (g_symbiface.enabled) symbiface_mouse_update(dx, dy, buttons);
 }
 
 static bool has_path_traversal(const std::string& path) {
@@ -466,12 +497,26 @@ void init_command_registry() {
       "  frame [N]: Steps exactly N video frames (1/50th of a second).");
 
   register_command(
-      "input", "INPUT", "input key <scan> | input type <text>",
+      "input", "INPUT",
+      "input keydown|keyup|key <name> | input type <text> | "
+      "input joy <0|1> <dir> | input mouse <move|button|buttons> ...",
       "Simulate user input",
-      "Injects keyboard events directly into the emulated hardware.\n"
-      "  key: Toggles a specific CPC scancode.\n"
-      "  type: Automatically types a string of text. Supports WinAPE syntax "
-      "(e.g., ~RETURN~).");
+      "Injects keyboard/joystick/mouse events directly into the emulated "
+      "hardware.\n"
+      "  <name> is a friendly key name (RETURN, SPACE, ESC, F1, UP, ...) or a "
+      "single character (a, A, 1). See the cpc_key_names table.\n"
+      "  keydown: Presses and holds <name> (matrix bit stays set).\n"
+      "  keyup:   Releases <name>.\n"
+      "  key:     Taps <name> (press, hold 2 frames, release).\n"
+      "  type:    Types a literal string. Only mapped characters are emitted; "
+      "WinAPE ~KEY~ syntax is NOT supported here -- use the 'autotype' command "
+      "for that.\n"
+      "  joy:     Sets joystick <0|1> direction <dir> (U/D/L/R/F1/F2, or 0 to "
+      "release all). Prefix <dir> with '-' to release a single direction.\n"
+      "  mouse:   Drives the AMX/Symbiface mouse. 'move <dx> <dy>' feeds "
+      "relative motion; 'button <L|M|R> <down|up>' sets one button; "
+      "'buttons <mask>' sets the whole SDL button mask. Requires a mouse "
+      "device to be enabled.");
 
   register_command(
       "disk", "HARDWARE", "disk ls <A|B> | disk put <A|B> <path>",
@@ -2239,10 +2284,55 @@ std::string handle_command(const std::string& line) {
         ipc_apply_keypress(scancode, keyboard_matrix, !release);
         return "OK\n";
       }
-      return "ERR 400 bad-input-cmd (keydown|keyup|key|type|joy)\n";
+      if (parts[1] == "mouse" && parts.size() >= 3) {
+        // Mouse input is staged here and flushed on the main thread by
+        // ipc_drain_input() — see the IpcMousePending comment above.
+        if (!g_amx_mouse.enabled && !g_symbiface.enabled)
+          return "ERR 409 no-mouse-device (enable AMX or Symbiface mouse)\n";
+        if (parts[2] == "move" && parts.size() >= 5) {
+          g_ipc_mouse.dx.fetch_add(parse_int(parts[3]),
+                                   std::memory_order_relaxed);
+          g_ipc_mouse.dy.fetch_add(parse_int(parts[4]),
+                                   std::memory_order_relaxed);
+          g_ipc_mouse.dirty.store(true, std::memory_order_release);
+          return "OK\n";
+        }
+        if (parts[2] == "button" && parts.size() >= 5) {
+          std::string btn = parts[3];
+          for (auto& c : btn)
+            c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+          uint32_t bit = 0;
+          if (btn == "L" || btn == "LEFT")
+            bit = 1u;  // SDL_BUTTON_LMASK
+          else if (btn == "M" || btn == "MIDDLE")
+            bit = 2u;  // SDL_BUTTON_MMASK
+          else if (btn == "R" || btn == "RIGHT")
+            bit = 4u;  // SDL_BUTTON_RMASK
+          else
+            return "ERR 400 bad-button (L|M|R)\n";
+          if (parts[4] == "down")
+            g_ipc_mouse.buttons.fetch_or(bit, std::memory_order_relaxed);
+          else if (parts[4] == "up")
+            g_ipc_mouse.buttons.fetch_and(~bit, std::memory_order_relaxed);
+          else
+            return "ERR 400 bad-button-state (down|up)\n";
+          g_ipc_mouse.dirty.store(true, std::memory_order_release);
+          return "OK\n";
+        }
+        if (parts[2] == "buttons" && parts.size() >= 4) {
+          g_ipc_mouse.buttons.store(
+              static_cast<uint32_t>(parse_int(parts[3])),
+              std::memory_order_relaxed);
+          g_ipc_mouse.dirty.store(true, std::memory_order_release);
+          return "OK\n";
+        }
+        return "ERR 400 bad-mouse-cmd (move <dx> <dy> | button <L|M|R> "
+               "<down|up> | buttons <mask>)\n";
+      }
+      return "ERR 400 bad-input-cmd (keydown|keyup|key|type|joy|mouse)\n";
     }
     if (cmd == "input")
-      return "ERR 400 usage: input (keydown|keyup|key|type|joy)\n";
+      return "ERR 400 usage: input (keydown|keyup|key|type|joy|mouse)\n";
 
     if (cmd == "wait" && parts.size() >= 2) {
       auto timeout_ms = std::chrono::milliseconds(5000);

--- a/src/koncepcja_ipc_server.cpp
+++ b/src/koncepcja_ipc_server.cpp
@@ -36,6 +36,7 @@
 #endif
 
 #include "SDL3/SDL.h"
+#include "amx_mouse.h"
 #include "asic_debug.h"
 #include "avi_recorder.h"
 #include "config_profile.h"
@@ -48,7 +49,6 @@
 #include "disk_format.h"
 #include "disk_sector_editor.h"
 #include "drive_status.h"
-#include "amx_mouse.h"
 #include "expr_parser.h"
 #include "gif_recorder.h"
 #include "imgui_ui_testable.h"

--- a/src/koncepcja_ipc_server.cpp
+++ b/src/koncepcja_ipc_server.cpp
@@ -243,6 +243,10 @@ struct IpcMousePending {
   int32_t dy{0};
   uint32_t buttons{0};  // SDL button mask (Left=1, Middle=2, Right=4)
   std::atomic<bool> dirty{false};  // fast-path: skip the lock when idle
+  // Published by the main thread each frame so the IPC thread can gate the
+  // "no mouse device" error without reading the peripherals' plain-bool enabled
+  // flags cross-thread (those flags are written on the main thread).
+  std::atomic<bool> device_active{false};
 };
 IpcMousePending g_ipc_mouse;
 }  // namespace
@@ -253,6 +257,10 @@ IpcMousePending g_ipc_mouse;
 // and dy can never come from different updates (no shearing); the device
 // updates run unlocked.
 void ipc_drain_input() {
+  // Publish device-enabled state for the IPC thread's gate (read of the plain
+  // bool flags is safe here — this runs on the main thread that writes them).
+  g_ipc_mouse.device_active.store(g_amx_mouse.enabled || g_symbiface.enabled,
+                                  std::memory_order_relaxed);
   if (!g_ipc_mouse.dirty.load(std::memory_order_acquire)) return;
   int32_t dx = 0;
   int32_t dy = 0;
@@ -2304,7 +2312,7 @@ std::string handle_command(const std::string& line) {
       if (parts[1] == "mouse" && parts.size() >= 3) {
         // Mouse input is staged here and flushed on the main thread by
         // ipc_drain_input() — see the IpcMousePending comment above.
-        if (!g_amx_mouse.enabled && !g_symbiface.enabled)
+        if (!g_ipc_mouse.device_active.load(std::memory_order_relaxed))
           return "ERR 409 no-mouse-device (enable AMX or Symbiface mouse)\n";
         if (parts[2] == "move" && parts.size() >= 5) {
           std::lock_guard<std::mutex> lock(g_ipc_mouse.mutex);

--- a/src/koncepcja_ipc_server.h
+++ b/src/koncepcja_ipc_server.h
@@ -88,3 +88,8 @@ class KoncepcjaIpcServer {
 void ipc_check_pc_events(uint16_t pc);
 void ipc_check_mem_write_events(uint16_t addr, uint8_t val);
 void ipc_check_vbl_events();
+
+// Flush staged IPC input (mouse deltas/buttons) into the emulated devices.
+// MUST be called once per frame on the main thread — the IPC server thread only
+// accumulates; this applies. Cheap no-op when nothing is pending.
+void ipc_drain_input();

--- a/test/amx_mouse.cpp
+++ b/test/amx_mouse.cpp
@@ -1,0 +1,97 @@
+#include "amx_mouse.h"
+
+#include <gtest/gtest.h>
+
+// The AMX Mouse appears on the joystick-port keyboard-matrix row 9 (active-low:
+// a cleared bit means "active"). These tests exercise the pure device logic
+// that the IPC `input mouse` commands feed via amx_mouse_update() — motion
+// accumulation, the row-9 direction/button bit encoding, and the
+// deselect/reselect mickey-consumption handshake.
+class AmxMouseTest : public ::testing::Test {
+ protected:
+  void SetUp() override { amx_mouse_reset(); }
+};
+
+TEST_F(AmxMouseTest, ResetClearsState) {
+  amx_mouse_update(5.0f, -3.0f, 0x07);
+  amx_mouse_reset();
+  EXPECT_EQ(0, g_amx_mouse.mickey_x);
+  EXPECT_EQ(0, g_amx_mouse.mickey_y);
+  EXPECT_EQ(0, g_amx_mouse.buttons);
+  EXPECT_NEAR(0.0f, g_amx_mouse.accum_x, 1e-6f);
+  EXPECT_NEAR(0.0f, g_amx_mouse.accum_y, 1e-6f);
+  EXPECT_EQ(0xFF, amx_mouse_get_row9());  // nothing active
+}
+
+TEST_F(AmxMouseTest, WholePixelMotionAccumulatesMickeys) {
+  amx_mouse_update(5.0f, 3.0f, 0);
+  EXPECT_EQ(5, g_amx_mouse.mickey_x);
+  EXPECT_EQ(3, g_amx_mouse.mickey_y);
+  // Subsequent motion adds to the pending mickey counters.
+  amx_mouse_update(-2.0f, -1.0f, 0);
+  EXPECT_EQ(3, g_amx_mouse.mickey_x);
+  EXPECT_EQ(2, g_amx_mouse.mickey_y);
+}
+
+TEST_F(AmxMouseTest, SubPixelMotionAccumulatesUntilWhole) {
+  amx_mouse_update(0.4f, 0.0f, 0);
+  EXPECT_EQ(0, g_amx_mouse.mickey_x);  // 0.4 — no whole mickey yet
+  amx_mouse_update(0.4f, 0.0f, 0);
+  EXPECT_EQ(0, g_amx_mouse.mickey_x);  // 0.8 — still none
+  amx_mouse_update(0.4f, 0.0f, 0);
+  EXPECT_EQ(1, g_amx_mouse.mickey_x);  // 1.2 — one mickey, 0.2 carried over
+  EXPECT_NEAR(0.2f, g_amx_mouse.accum_x, 1e-3f);
+}
+
+// ── Row-9 direction encoding (active-low) ──────────────────────────────
+TEST_F(AmxMouseTest, PositiveXIsRight) {
+  amx_mouse_update(1.0f, 0.0f, 0);
+  EXPECT_EQ(0xFF & ~0x08, amx_mouse_get_row9());
+}
+TEST_F(AmxMouseTest, NegativeXIsLeft) {
+  amx_mouse_update(-1.0f, 0.0f, 0);
+  EXPECT_EQ(0xFF & ~0x04, amx_mouse_get_row9());
+}
+TEST_F(AmxMouseTest, NegativeYIsUp) {
+  amx_mouse_update(0.0f, -1.0f, 0);
+  EXPECT_EQ(0xFF & ~0x01, amx_mouse_get_row9());
+}
+TEST_F(AmxMouseTest, PositiveYIsDown) {
+  amx_mouse_update(0.0f, 1.0f, 0);
+  EXPECT_EQ(0xFF & ~0x02, amx_mouse_get_row9());
+}
+
+// ── Button encoding (SDL mask -> row-9 fire bits) ──────────────────────
+TEST_F(AmxMouseTest, LeftButtonMapsToFire2) {
+  amx_mouse_update(0.0f, 0.0f, 1);  // SDL_BUTTON_LMASK
+  EXPECT_EQ(0xFF & ~0x10, amx_mouse_get_row9());
+}
+TEST_F(AmxMouseTest, RightButtonMapsToFire1) {
+  amx_mouse_update(0.0f, 0.0f, 4);  // SDL_BUTTON_RMASK
+  EXPECT_EQ(0xFF & ~0x20, amx_mouse_get_row9());
+}
+TEST_F(AmxMouseTest, MiddleButtonMapsToFire3) {
+  amx_mouse_update(0.0f, 0.0f, 2);  // SDL_BUTTON_MMASK
+  EXPECT_EQ(0xFF & ~0x40, amx_mouse_get_row9());
+}
+TEST_F(AmxMouseTest, MotionAndButtonsCombine) {
+  amx_mouse_update(1.0f, 0.0f, 1);  // right + left button
+  EXPECT_EQ(0xFF & ~0x08 & ~0x10, amx_mouse_get_row9());
+}
+
+// ── Deselect/reselect handshake consumes one mickey per axis ───────────
+TEST_F(AmxMouseTest, RowSelectCycleConsumesOneMickeyPerAxis) {
+  amx_mouse_update(3.0f, -2.0f, 0);
+  amx_mouse_row_select(9);  // select row 9
+  amx_mouse_row_select(5);  // deselect (software reads another row)
+  amx_mouse_row_select(9);  // reselect -> consume one mickey toward zero
+  EXPECT_EQ(2, g_amx_mouse.mickey_x);
+  EXPECT_EQ(-1, g_amx_mouse.mickey_y);
+}
+
+TEST_F(AmxMouseTest, ReselectWithoutDeselectDoesNotConsume) {
+  amx_mouse_update(3.0f, 0.0f, 0);
+  amx_mouse_row_select(9);
+  amx_mouse_row_select(9);  // no intervening deselect -> no consumption
+  EXPECT_EQ(3, g_amx_mouse.mickey_x);
+}

--- a/test/integrated/ipc_harness.py
+++ b/test/integrated/ipc_harness.py
@@ -533,6 +533,55 @@ def test_step_in_accuracy():
         return True
 
 
+def test_mouse_input():
+    """IPC mouse input: device gating + full command surface.
+
+    Verifies the 'input mouse' command layer:
+      - rejected when no mouse device is enabled,
+      - move/button/buttons accepted once the AMX mouse is enabled,
+      - malformed sub-commands are rejected.
+    Actual pointer motion is exercised by the SDL path; this asserts the IPC
+    contract (which is all the server is responsible for).
+    """
+    print("Running mouse input test...")
+
+    # 1. No mouse device -> commands rejected.
+    with EmulatorRunner() as emu:
+        if not emu.start():
+            print("FAIL: Could not start emulator")
+            return False
+        ok, resp = emu.ipc.send_command('input mouse move 5 5')
+        if ok:
+            print(f"FAIL: expected ERR with no mouse device, got OK: {resp!r}")
+            return False
+        print(f"  no-device rejected as expected: {resp.strip()}")
+
+    # 2. AMX mouse enabled -> full surface works, bad args rejected.
+    with EmulatorRunner() as emu:
+        if not emu.start('-O', 'input.amx_mouse=1'):
+            print("FAIL: Could not start emulator with AMX mouse")
+            return False
+
+        checks = [
+            ('input mouse move 10 -4', True),
+            ('input mouse button L down', True),
+            ('input mouse button R up', True),
+            ('input mouse buttons 0', True),
+            ('input mouse button X down', False),  # bad button
+            ('input mouse wiggle', False),         # bad sub-command
+            ('input mouse move 1', False),         # missing dy
+        ]
+        for cmd, want_ok in checks:
+            ok, resp = emu.ipc.send_command(cmd)
+            if ok != want_ok:
+                print(f"FAIL: {cmd!r} -> ok={ok} (wanted {want_ok}): {resp.strip()}")
+                return False
+            print(f"  {cmd!r} -> {resp.strip()}")
+
+        print("PASS: mouse input test")
+        return True
+
+
 def main():
     """Run all IPC tests."""
     print("=" * 50)
@@ -548,6 +597,7 @@ def main():
         test_snapshot_round_trip,
         test_rapid_pause_resume,
         test_step_in_accuracy,
+        test_mouse_input,
     ]
 
     passed = 0

--- a/test/integrated/ipc_harness.py
+++ b/test/integrated/ipc_harness.py
@@ -582,6 +582,40 @@ def test_mouse_input():
         return True
 
 
+def test_joystick_input():
+    """IPC joystick input: the 'input joy' command surface.
+
+    The device-level behaviour (J0 -> matrix row 9, J1 -> row 6, press toggles
+    the right bit) is covered by the JoystickInputTest gtest suite; this asserts
+    the IPC command contract end-to-end.
+    """
+    print("Running joystick input test...")
+
+    with EmulatorRunner() as emu:
+        if not emu.start():
+            print("FAIL: Could not start emulator")
+            return False
+
+        checks = [
+            ('input joy 0 U', True),       # joystick 0 up
+            ('input joy 0 -U', True),      # release up
+            ('input joy 0 F1', True),      # fire 1
+            ('input joy 1 RIGHT', True),   # joystick 1 right
+            ('input joy 0 0', True),       # release all directions
+            ('input joy 0 SIDEWAYS', False),  # bad direction
+            ('input joy', False),          # missing args
+        ]
+        for cmd, want_ok in checks:
+            ok, resp = emu.ipc.send_command(cmd)
+            if ok != want_ok:
+                print(f"FAIL: {cmd!r} -> ok={ok} (wanted {want_ok}): {resp.strip()}")
+                return False
+            print(f"  {cmd!r} -> {resp.strip()}")
+
+        print("PASS: joystick input test")
+        return True
+
+
 def main():
     """Run all IPC tests."""
     print("=" * 50)
@@ -598,6 +632,7 @@ def main():
         test_rapid_pause_resume,
         test_step_in_accuracy,
         test_mouse_input,
+        test_joystick_input,
     ]
 
     passed = 0

--- a/test/joystick_input.cpp
+++ b/test/joystick_input.cpp
@@ -10,10 +10,10 @@ extern byte bit_values[8];
 
 // Joysticks are read through the keyboard matrix: joystick 0 occupies row 9 and
 // joystick 1 occupies row 6 (active-low — a pressed direction/fire CLEARS its
-// bit). The IPC `input joy <n> <dir>` command resolves CPC_J0_*/CPC_J1_* via the
-// InputMapper to these scancodes and pokes the matrix exactly like a keypress.
-// These tests pin both halves of that path: the CPC_KEYS -> scancode mapping,
-// and that applying a scancode toggles the expected matrix bit.
+// bit). The IPC `input joy <n> <dir>` command resolves CPC_J0_*/CPC_J1_* via
+// the InputMapper to these scancodes and pokes the matrix exactly like a
+// keypress. These tests pin both halves of that path: the CPC_KEYS -> scancode
+// mapping, and that applying a scancode toggles the expected matrix bit.
 class JoystickInputTest : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -32,7 +32,8 @@ class JoystickInputTest : public ::testing::Test {
   bool is_pressed(CPCScancode sc) {
     int line = static_cast<byte>(sc) >> 4;
     int bit = static_cast<byte>(sc) & 7;
-    return (matrix[line].load(std::memory_order_relaxed) & bit_values[bit]) == 0;
+    return (matrix[line].load(std::memory_order_relaxed) & bit_values[bit]) ==
+           0;
   }
 
   std::atomic<byte> matrix[16];

--- a/test/joystick_input.cpp
+++ b/test/joystick_input.cpp
@@ -1,0 +1,85 @@
+#include <gtest/gtest.h>
+
+#include <atomic>
+
+#include "keyboard.h"
+#include "koncepcja.h"
+
+extern t_CPC CPC;
+extern byte bit_values[8];
+
+// Joysticks are read through the keyboard matrix: joystick 0 occupies row 9 and
+// joystick 1 occupies row 6 (active-low — a pressed direction/fire CLEARS its
+// bit). The IPC `input joy <n> <dir>` command resolves CPC_J0_*/CPC_J1_* via the
+// InputMapper to these scancodes and pokes the matrix exactly like a keypress.
+// These tests pin both halves of that path: the CPC_KEYS -> scancode mapping,
+// and that applying a scancode toggles the expected matrix bit.
+class JoystickInputTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    CPC.keyboard = 0;  // English layout (cpc_kbd[0])
+    if (CPC.InputMapper == nullptr) {
+      CPC.InputMapper = new InputMapper(&CPC);
+      CPC.InputMapper->init();
+    }
+    for (auto& cell : matrix) cell.store(0xFF, std::memory_order_relaxed);
+  }
+
+  CPCScancode scancode_of(CPC_KEYS key) {
+    return CPC.InputMapper->CPCscancodeFromCPCkey(key);
+  }
+
+  bool is_pressed(CPCScancode sc) {
+    int line = static_cast<byte>(sc) >> 4;
+    int bit = static_cast<byte>(sc) & 7;
+    return (matrix[line].load(std::memory_order_relaxed) & bit_values[bit]) == 0;
+  }
+
+  std::atomic<byte> matrix[16];
+};
+
+// ── Scancode mapping (catches enum/table reordering regressions) ───────
+TEST_F(JoystickInputTest, Joystick0KeysMapToRow9) {
+  EXPECT_EQ(0x90u, scancode_of(CPC_J0_UP));
+  EXPECT_EQ(0x91u, scancode_of(CPC_J0_DOWN));
+  EXPECT_EQ(0x92u, scancode_of(CPC_J0_LEFT));
+  EXPECT_EQ(0x93u, scancode_of(CPC_J0_RIGHT));
+  EXPECT_EQ(0x94u, scancode_of(CPC_J0_FIRE1));
+  EXPECT_EQ(0x95u, scancode_of(CPC_J0_FIRE2));
+}
+
+TEST_F(JoystickInputTest, Joystick1KeysMapToRow6) {
+  EXPECT_EQ(0x60u, scancode_of(CPC_J1_UP));
+  EXPECT_EQ(0x61u, scancode_of(CPC_J1_DOWN));
+  EXPECT_EQ(0x62u, scancode_of(CPC_J1_LEFT));
+  EXPECT_EQ(0x63u, scancode_of(CPC_J1_RIGHT));
+  EXPECT_EQ(0x64u, scancode_of(CPC_J1_FIRE1));
+  EXPECT_EQ(0x65u, scancode_of(CPC_J1_FIRE2));
+}
+
+// ── Matrix mechanics (the part `input joy` actually drives) ────────────
+TEST_F(JoystickInputTest, PressClearsBitReleaseRestoresIt) {
+  CPCScancode up = scancode_of(CPC_J0_UP);  // row 9, bit 0
+  applyKeypressDirect(up, matrix, true);
+  EXPECT_TRUE(is_pressed(up));
+  applyKeypressDirect(up, matrix, false);
+  EXPECT_FALSE(is_pressed(up));
+}
+
+TEST_F(JoystickInputTest, FireIsIndependentOfDirections) {
+  CPCScancode fire = scancode_of(CPC_J0_FIRE1);
+  applyKeypressDirect(fire, matrix, true);
+  EXPECT_TRUE(is_pressed(fire));
+  EXPECT_FALSE(is_pressed(scancode_of(CPC_J0_UP)));
+  EXPECT_FALSE(is_pressed(scancode_of(CPC_J0_DOWN)));
+}
+
+TEST_F(JoystickInputTest, Joystick0AndJoystick1AreOnDifferentRows) {
+  CPCScancode j0 = scancode_of(CPC_J0_UP);  // row 9
+  CPCScancode j1 = scancode_of(CPC_J1_UP);  // row 6
+  EXPECT_NE(static_cast<byte>(j0) >> 4, static_cast<byte>(j1) >> 4);
+  // Pressing joystick 0 up must not disturb joystick 1.
+  applyKeypressDirect(j0, matrix, true);
+  EXPECT_TRUE(is_pressed(j0));
+  EXPECT_FALSE(is_pressed(j1));
+}


### PR DESCRIPTION
## Summary
Extends the IPC input surface to the mouse, corrects the long-stale `input` command docs, and adds unit coverage for the input devices.

### Mouse input (epic beads-w3op, Phase 1 / beads-hh6d)
- New `input mouse move <dx> <dy>` / `button <L|M|R> <down|up>` / `buttons <mask>`.
- Staged via a new `ipc_drain_input()` flushed once per frame on the main thread (mirrors `g_m4_http.drain_pending` / `g_repaint_pending`), then fed into `amx_mouse_update` / `symbiface_mouse_update` — the same entry points SDL uses. Non-atomic device state is never touched from the IPC thread.
- Gated on an enabled mouse device (`ERR 409` otherwise).

### Doc fixes
The `input` help omitted `keydown`/`keyup`/`joy`, mislabelled `key` as a scancode toggle, and **falsely claimed `input type` supports WinAPE `~KEY~`** (that is `autotype`-only). Fixed in the command help, `AGENTS.md` and `docs/ipc-protocol.md` tables, plus a runnable `README.md` example so non-agent users can discover it.

### Tests
- `test/amx_mouse.cpp` (13) — motion accumulation, row-9 direction/button encoding, deselect/reselect handshake.
- `test/joystick_input.cpp` (5) — J0→row 9 / J1→row 6 mapping + matrix mechanics (verifies the joystick path `input joy` drives).
- `ipc_harness.py` — `test_mouse_input` + `test_joystick_input` contract tests.
- Full unit suite: **1151 passed**.

### Follow-ups filed in bd
- `beads-vrsr`/`nz0n`/`c8fn`/`bej2` — IPC input Phases 2–5 (lightgun, modifiers/timing, type-unify, state readback).
- `beads-p6im` — ipc_harness hardcodes port 6543 (tests a foreign instance if busy).
- `beads-x9fk` — release archive omits `docs/` (dead README link for binary users).

Manual subproject scaffolding is a separate branch/PR (`docs/manual-subproject`).