### PR TITLE
ci(pr-title): require and enforce Conventional Commit PR titles

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,49 @@
+name: PR Title Lint
+
+# Enforces the Conventional-Commits convention documented in AGENTS.md.
+# Because PRs are squash-merged, the PR TITLE becomes the commit message that
+# lands on master and that release-please classifies to compute the next
+# version. A wrong/missing prefix would silently skip or mis-size a release,
+# so this gate fails the PR until the title is a valid Conventional Commit.
+#
+# To make it actually block merging, add "Validate PR title" to the branch's
+# required status checks (Settings → Branches → branch protection for master).
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Keep in sync with release-please-config.json changelog-sections.
+          types: |
+            feat
+            fix
+            perf
+            docs
+            chore
+            refactor
+            test
+            ci
+            style
+            build
+            revert
+          # Scopes are optional, e.g. feat(ipc): ...
+          requireScope: false
+          # Allow a single commit's message to be used as the title when a PR
+          # has exactly one commit (GitHub's default squash behaviour).
+          validateSingleCommit: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -487,6 +487,30 @@ Recurring patterns from code reviews. Follow these to avoid common pitfalls:
 - **Track string lengths explicitly** — When packing strings into fixed-width fields (like ATA IDENTIFY), compute `strlen` once and bounds-check per-character access. Don't rely on null-terminator proximity to short-circuit evaluation.
 - **Path traversal protection** — Any user-supplied path (IPC, M4 virtual FS) must be validated: reject `..`, absolute paths, and symlink escapes.
 
+## Commit & PR Conventions
+
+**All commit messages AND pull-request titles MUST follow [Conventional Commits](https://www.conventionalcommits.org):**
+
+```
+<type>(<optional scope>): <description>
+```
+
+Releases are automated by **release-please** (`.github/workflows/release-please.yml`), which reads these prefixes to compute the next version. **PRs are squash-merged, so the PR _title_ becomes the commit message release-please classifies** — the title must honestly reflect the change's impact, or the version bump will be wrong (or skipped).
+
+| Prefix | Meaning | Release effect |
+|--------|---------|----------------|
+| `feat:` | New user-facing capability | **minor** (x.**Y**.0) |
+| `fix:` / `perf:` | Bug fix / performance | **patch** (x.y.**Z**) |
+| `feat!:` / `fix!:`, or a `BREAKING CHANGE:` footer | Backwards-incompatible change | **major** (**X**.0.0) |
+| `docs:` `chore:` `refactor:` `test:` `ci:` `style:` `build:` | No user-facing change | **no release** |
+
+**Rules:**
+- Choose the prefix by the change's **actual impact, not its size**. A one-line change adding an IPC command is a `feat:`; a large internal refactor with no behaviour change is `refactor:`.
+- Never understate: a mislabeled `chore:` that actually adds a feature silently skips the version bump. When unsure between two levels, pick the higher one.
+- Mark breaking changes with `!` (e.g. `feat!:`) **or** a `BREAKING CHANGE:` footer — a renamed/removed IPC command, changed reply format, or config-incompatible change qualifies.
+- Use a scope when it sharpens intent: `feat(ipc):`, `fix(crtc):`, `chore(build):`.
+- This governs the **squash-merge title** above all else, since that is the only message that lands on `master`.
+
 ## CI / Merging
 
 - **NEVER merge a PR with failing CI checks.** Fix failures first.


### PR DESCRIPTION
## What

Establishes Conventional Commits as a rule **and** enforces it automatically:

1. **`AGENTS.md`** — new "Commit & PR Conventions" section requiring Conventional Commits for all commits and PR titles (governs Claude/Codex/Cursor/Gemini via the `CLAUDE.md → AGENTS.md` symlink). Includes a prefix → release-effect table and "classify by impact, not size" rules.
2. **`.github/workflows/pr-title-lint.yml`** — a `pull_request` gate (`amannn/action-semantic-pull-request@v5`) that validates the **PR title** on open/edit/sync and fails if it isn't a valid Conventional Commit. Allowed types kept in sync with `release-please-config.json`.

## Why

`release-please` computes the next version from commit prefixes. Since **PRs are squash-merged, the PR title is the message that lands on master and gets classified** — a wrong/missing prefix silently skips or mis-sizes a release. The doc states the rule; the gate makes it unbypassable.

## ⚠️ To make the gate actually block merges

Add **"Validate PR title"** to master's **required status checks** (Settings → Branches → branch protection). Until then it runs and reports but won't hard-block.

This PR's own title (`ci(pr-title): …`) is validated by the very gate it adds.